### PR TITLE
cmake script improvements

### DIFF
--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -1,12 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
-project(eventheader-decode-cpp)
+project(eventheader-decode-cpp
+    VERSION 1.0.0
+    DESCRIPTION "EventHeader tracepoint decoding for C/C++"
+    HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
+    LANGUAGES C CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 set(BUILD_TOOLS ON CACHE BOOL "Build tool code")
 
 if(NOT TARGET eventheader-headers)
-    find_package(eventheader-headers)
+    find_package(eventheader-headers 1.0 REQUIRED
+        NAMES eventheader-headers libeventheader-tracepoint)
 endif()
 
 if(WIN32)

--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -10,8 +10,7 @@ set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 set(BUILD_TOOLS ON CACHE BOOL "Build tool code")
 
 if(NOT TARGET eventheader-headers)
-    find_package(eventheader-headers 1.0 REQUIRED
-        NAMES libeventheader-tracepoint)
+    find_package(eventheader-headers 1.0 REQUIRED)
 endif()
 
 if(WIN32)

--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BUILD_TOOLS ON CACHE BOOL "Build tool code")
 
 if(NOT TARGET eventheader-headers)
     find_package(eventheader-headers 1.0 REQUIRED
-        NAMES eventheader-headers libeventheader-tracepoint)
+        NAMES libeventheader-tracepoint)
 endif()
 
 if(WIN32)

--- a/libeventheader-decode-cpp/src/CMakeLists.txt
+++ b/libeventheader-decode-cpp/src/CMakeLists.txt
@@ -35,6 +35,10 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/eventheader-decode"
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/eventheader-decodeConfigVersion.cmake"
+    COMPATIBILITY SameMinorVersion)
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/eventheader-decodeConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/eventheader-decodeConfigVersion.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/eventheader-decode")

--- a/libeventheader-decode-cpp/tools/CMakeLists.txt
+++ b/libeventheader-decode-cpp/tools/CMakeLists.txt
@@ -4,3 +4,4 @@ target_link_libraries(decode-perf
     eventheader-decode)
 target_compile_features(decode-perf
     PRIVATE cxx_std_17)
+install(TARGETS decode-perf)

--- a/libeventheader-decode-dotnet/CMakeLists.txt
+++ b/libeventheader-decode-dotnet/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
-project(eventheader-decode-dotnet CSharp)
+project(eventheader-decode-dotnet
+    VERSION 1.0.0
+    DESCRIPTION "EventHeader tracepoint decoding for .NET"
+    HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
+    LANGUAGES CSharp)
 include(GNUInstallDirs)
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
-project(eventheader-tracepoint)
+project(eventheader-tracepoint
+    VERSION 1.0.0
+    DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++"
+    HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
+    LANGUAGES C CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
@@ -26,11 +30,13 @@ add_subdirectory(include)
 if(NOT WIN32)
 
     if(NOT TARGET tracepoint-headers)
-        find_package(tracepoint-headers)
+        find_package(tracepoint-headers 1.0 REQUIRED
+            NAMES tracepoint-headers libtracepoint)
     endif()
 
     if(NOT TARGET tracepoint)
-        find_package(tracepoint)
+        find_package(tracepoint 1.0 REQUIRED
+            NAMES tracepoint libtracepoint)
     endif()
 
     add_subdirectory(src)

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -31,12 +31,12 @@ if(NOT WIN32)
 
     if(NOT TARGET tracepoint-headers)
         find_package(tracepoint-headers 1.0 REQUIRED
-            NAMES tracepoint-headers libtracepoint)
+            NAMES libtracepoint)
     endif()
 
     if(NOT TARGET tracepoint)
         find_package(tracepoint 1.0 REQUIRED
-            NAMES tracepoint libtracepoint)
+            NAMES libtracepoint)
     endif()
 
     add_subdirectory(src)

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -30,13 +30,11 @@ add_subdirectory(include)
 if(NOT WIN32)
 
     if(NOT TARGET tracepoint-headers)
-        find_package(tracepoint-headers 1.0 REQUIRED
-            NAMES libtracepoint)
+        find_package(tracepoint-headers 1.0 REQUIRED)
     endif()
 
     if(NOT TARGET tracepoint)
-        find_package(tracepoint 1.0 REQUIRED
-            NAMES libtracepoint)
+        find_package(tracepoint 1.0 REQUIRED)
     endif()
 
     add_subdirectory(src)

--- a/libeventheader-tracepoint/include/CMakeLists.txt
+++ b/libeventheader-tracepoint/include/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
-project(eventheader-tracepoint-headers)
+project(eventheader-tracepoint-headers
+    VERSION 1.0.0
+    DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++ (headers)"
+    HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
+    LANGUAGES C CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
@@ -11,6 +15,7 @@ target_include_directories(eventheader-headers
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 set(EVENTHEADER_HEADERS
     "${PROJECT_SOURCE_DIR}/eventheader/eventheader.h"
+    "${PROJECT_SOURCE_DIR}/eventheader/EventHeaderDynamic.h"
     "${PROJECT_SOURCE_DIR}/eventheader/eventheader-tracepoint.h"
     "${PROJECT_SOURCE_DIR}/eventheader/TraceLoggingProvider.h")
 set_target_properties(eventheader-headers PROPERTIES
@@ -27,6 +32,10 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/eventheader-headers"
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/eventheader-headersConfigVersion.cmake"
+    COMPATIBILITY SameMinorVersion)
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/eventheader-headersConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/eventheader-headersConfigVersion.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/eventheader-headers")

--- a/libeventheader-tracepoint/src/CMakeLists.txt
+++ b/libeventheader-tracepoint/src/CMakeLists.txt
@@ -14,6 +14,10 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/eventheader-tracepoint"
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/eventheader-tracepointConfigVersion.cmake"
+    COMPATIBILITY SameMinorVersion)
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/eventheader-tracepointConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/eventheader-tracepointConfigVersion.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/eventheader-tracepoint")

--- a/libeventheader-tracepoint/src/eventheader-tracepointConfig.cmake.in
+++ b/libeventheader-tracepoint/src/eventheader-tracepointConfig.cmake.in
@@ -1,7 +1,8 @@
 @PACKAGE_INIT@
 
 if(NOT TARGET eventheader-headers)
-    find_package(eventheader-headers)
+    find_package(eventheader-headers 1.0 REQUIRED
+        NAMES eventheader-headers libeventheader-tracepoint)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/eventheader-tracepointTargets.cmake")

--- a/libeventheader-tracepoint/src/eventheader-tracepointConfig.cmake.in
+++ b/libeventheader-tracepoint/src/eventheader-tracepointConfig.cmake.in
@@ -1,8 +1,7 @@
 @PACKAGE_INIT@
 
 if(NOT TARGET eventheader-headers)
-    find_package(eventheader-headers 1.0 REQUIRED
-        NAMES eventheader-headers libeventheader-tracepoint)
+    find_package(eventheader-headers 1.0 REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/eventheader-tracepointTargets.cmake")

--- a/libeventheader-tracepoint/tools/CMakeLists.txt
+++ b/libeventheader-tracepoint/tools/CMakeLists.txt
@@ -2,3 +2,4 @@ add_executable(eventheader-register
     eventheader-register.cpp)
 target_link_libraries(eventheader-register
     PUBLIC eventheader-tracepoint tracepoint)
+install(TARGETS eventheader-register)

--- a/libtracepoint/CMakeLists.txt
+++ b/libtracepoint/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
-project(tracepoint)
+project(tracepoint
+    VERSION 1.0.0
+    DESCRIPTION "Linux tracepoints interface for C/C++"
+    HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
+    LANGUAGES C CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")

--- a/libtracepoint/include/CMakeLists.txt
+++ b/libtracepoint/include/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
-project(tracepoint-headers)
+project(tracepoint-headers
+    VERSION 1.0.0
+    DESCRIPTION "Linux tracepoints interface for C/C++ (headers)"
+    HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
+    LANGUAGES C CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
@@ -27,6 +31,10 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tracepoint-headers"
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/tracepoint-headersConfigVersion.cmake"
+    COMPATIBILITY SameMinorVersion)
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/tracepoint-headersConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/tracepoint-headersConfigVersion.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tracepoint-headers")

--- a/libtracepoint/src/CMakeLists.txt
+++ b/libtracepoint/src/CMakeLists.txt
@@ -15,6 +15,10 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tracepoint"
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/tracepointConfigVersion.cmake"
+    COMPATIBILITY SameMinorVersion)
 install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/tracepointConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/tracepointConfigVersion.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tracepoint")

--- a/libtracepoint/src/tracepointConfig.cmake.in
+++ b/libtracepoint/src/tracepointConfig.cmake.in
@@ -1,7 +1,8 @@
 @PACKAGE_INIT@
 
-if(NOT TARGET eventheader-headers)
-    find_package(tracepoint-headers)
+if(NOT TARGET tracepoint-headers)
+    find_package(tracepoint-headers 1.0 REQUIRED
+        NAMES tracepoint-headers libtracepoint)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/tracepointTargets.cmake")

--- a/libtracepoint/src/tracepointConfig.cmake.in
+++ b/libtracepoint/src/tracepointConfig.cmake.in
@@ -1,8 +1,7 @@
 @PACKAGE_INIT@
 
 if(NOT TARGET tracepoint-headers)
-    find_package(tracepoint-headers 1.0 REQUIRED
-        NAMES tracepoint-headers libtracepoint)
+    find_package(tracepoint-headers 1.0 REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/tracepointTargets.cmake")


### PR DESCRIPTION
Improvements prompted by getting the repository working with vcpkg.

The main one is adding the `NAMES` qualifier to the `find_package` commands. Version numbers are also probably a good thing.

- Add version numbers.
- Find package config files in either the component's folder (where we install them and where they will be found in a pure-cmake environment) or in the package's folder (where VCPKG moves them).
- Add `install` steps for the `decode-perf` and `eventheader-register` tools.
- Add `EventHeaderDynamic.h` to the list of published headers.
- Fix the condition under which we will try to find the tracepoint-headers config files (copy-paste error).