### PR TITLE
PerfDataDecode - split out new header PerfEventInfo.h

### DIFF
--- a/libeventheader-decode-cpp/include/PerfDataDecode/PerfEventInfo.h
+++ b/libeventheader-decode-cpp/include/PerfDataDecode/PerfEventInfo.h
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef _included_PerfEventInfo_h
+#define _included_PerfEventInfo_h
+
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <sal.h>
+#endif
+#ifndef _Field_z_
+#define _Field_z_
+#endif
+#ifndef _Field_size_bytes_
+#define _Field_size_bytes_(size)
+#endif
+
+// Forward declaration from PerfEventMetadata.h:
+class PerfEventMetadata;
+
+// Forward declaration from PerfDataAbi.h or linux/uapi/linux/perf_event.h:
+struct perf_event_attr;
+
+struct PerfSampleEventInfo
+{
+    uint64_t id;                            // Always valid if GetSampleEventInfo succeeded.
+    perf_event_attr const* attr;            // Always valid if GetSampleEventInfo succeeded.
+    _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
+    uint64_t sample_type;                   // Bit set if corresponding info present in event.
+    uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
+    uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
+    uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
+    uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
+    uint64_t ip;                            // Valid if sample_type & PERF_SAMPLE_IP.
+    uint64_t addr;                          // Valid if sample_type & PERF_SAMPLE_ADDR.
+    uint64_t period;                        // Valid if sample_type & PERF_SAMPLE_PERIOD.
+    uint64_t const* read_values;            // Valid if sample_type & PERF_SAMPLE_READ. Points into event.
+    uint64_t const* callchain;              // Valid if sample_type & PERF_SAMPLE_CALLCHAIN. Points into event.
+    PerfEventMetadata const* raw_meta;      // Valid if sample_type & PERF_SAMPLE_RAW. NULL if event unknown.
+    _Field_size_bytes_(raw_data_size) void const* raw_data; // Valid if sample_type & PERF_SAMPLE_RAW. Points into event.
+    uintptr_t raw_data_size;                   // Valid if sample_type & PERF_SAMPLE_RAW. Size of raw_data.
+};
+
+struct PerfNonSampleEventInfo
+{
+    uint64_t id;                            // Always valid if GetNonSampleEventInfo succeeded.
+    perf_event_attr const* attr;            // Always valid if GetNonSampleEventInfo succeeded.
+    _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
+    uint64_t sample_type;                   // Bit set if corresponding info present in event.
+    uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
+    uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
+    uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
+    uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
+};
+
+#endif // _included_PerfEventInfo_h

--- a/libeventheader-decode-cpp/include/PerfDataDecode/PerfEventMetadata.h
+++ b/libeventheader-decode-cpp/include/PerfDataDecode/PerfEventMetadata.h
@@ -43,7 +43,7 @@ enum PerfFieldArray : uint8_t
 
 class PerfFieldMetadata
 {
-    static constexpr std::string_view noname = std::string_view("noname");
+    static constexpr std::string_view noname = std::string_view("noname", 6);
 
     std::string_view m_name;     // deduced from field, e.g. "my_field".
     std::string_view m_field;    // value of "field:" property, e.g. "char my_field[8]".
@@ -149,7 +149,7 @@ public:
     std::string_view
     GetFieldBytes(
         _In_reads_bytes_(eventRawDataSize) void const* eventRawData,
-        size_t eventRawDataSize,
+        uintptr_t eventRawDataSize,
         bool fileBigEndian) const noexcept;
 };
 

--- a/libeventheader-decode-cpp/src/EventFormatter.cpp
+++ b/libeventheader-decode-cpp/src/EventFormatter.cpp
@@ -3,7 +3,8 @@
 
 #include <eventheader/EventFormatter.h>
 #include <PerfDataDecode/PerfEventMetadata.h>
-#include <PerfDataDecode/PerfDataFile.h>
+#include <PerfDataDecode/PerfEventInfo.h>
+#include <PerfDataDecode/PerfDataReader.h>
 #include <PerfDataDecode/PerfDataAbi.h>
 
 #include <assert.h>

--- a/libeventheader-decode-cpp/src/PerfDataFile.cpp
+++ b/libeventheader-decode-cpp/src/PerfDataFile.cpp
@@ -4,6 +4,7 @@
 #include <PerfDataDecode/PerfDataFile.h>
 #include <PerfDataDecode/PerfDataAbi.h>
 #include <PerfDataDecode/PerfEventMetadata.h>
+#include <PerfDataDecode/PerfEventInfo.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -167,14 +168,14 @@ PerfDataFile::DataEndFilePos() const noexcept
     return m_dataEndFilePos;
 }
 
-size_t
+uintptr_t
 PerfDataFile::AttrCount() const noexcept
 {
     return m_attrsList.size();
 }
 
 perf_event_attr const&
-PerfDataFile::Attr(size_t attrIndex) const noexcept
+PerfDataFile::Attr(uintptr_t attrIndex) const noexcept
 {
     assert(attrIndex < m_attrsList.size());
     return *m_attrsList[attrIndex];
@@ -1449,7 +1450,7 @@ PerfDataFile::AddAttr(
     uint32_t cbAttrCopied,
     _In_z_ char const* pName,
     _In_reads_bytes_(cbIdsFileEndian) void const* pbIdsFileEndian,
-    size_t cbIdsFileEndian) noexcept(false)
+    uintptr_t cbIdsFileEndian) noexcept(false)
 {
     assert(cbAttrCopied <= sizeof(perf_event_attr));
     auto const pAttr = pAttrPtr.get();
@@ -1581,7 +1582,7 @@ PerfDataFile::SectionValid(perf_file_section const& section) const noexcept
 }
 
 _Success_(return == 0) int
-PerfDataFile::FileRead(_Out_writes_bytes_all_(cb) void* p, size_t cb) noexcept
+PerfDataFile::FileRead(_Out_writes_bytes_all_(cb) void* p, uintptr_t cb) noexcept
 {
     auto pLeft = static_cast<uint8_t*>(p);
     auto cLeft = cb;
@@ -1635,7 +1636,7 @@ _Success_(return == 0) int
 PerfDataFile::FileSeekAndRead(
     uint64_t filePos,
     _Out_writes_bytes_all_(cb) void* p,
-    size_t cb) noexcept
+    uintptr_t cb) noexcept
 {
     int error = FileSeek(filePos);
     return error ? error : FileRead(p, cb);

--- a/libeventheader-decode-cpp/src/PerfEventMetadata.cpp
+++ b/libeventheader-decode-cpp/src/PerfEventMetadata.cpp
@@ -622,7 +622,7 @@ TokensDone:
 std::string_view
 PerfFieldMetadata::GetFieldBytes(
     _In_reads_bytes_(eventRawDataSize) void const* eventRawData,
-    size_t eventRawDataSize,
+    uintptr_t eventRawDataSize,
     bool fileBigEndian) const noexcept
 {
     std::string_view result;

--- a/libeventheader-decode-cpp/tools/decode-perf.cpp
+++ b/libeventheader-decode-cpp/tools/decode-perf.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <PerfDataDecode/PerfEventInfo.h>
 #include <PerfDataDecode/PerfDataFile.h>
 #include <PerfDataDecode/PerfDataAbi.h>
 #include <eventheader/EventFormatter.h>


### PR DESCRIPTION
The PerfDataDecode library's PerfDataFile.h header is for decoding a perf.data file. It contains structs that define "stuff you need to know about an event" (similar to ETW's `EVENT_RECORD`). These structs are useful in cases other than decoding a perf.data file, so they shouldn't be tied to PerfDataFile.h. Move them to their own header, where they can stand on their own.

Proof that this is a good idea: note that EventFormatter.cpp no longer needs to include PerfDataFile.h.