### PR TITLE
Rename PerfDataReader to PerfByteReader

### DIFF
--- a/libeventheader-decode-cpp/include/PerfDataDecode/PerfByteReader.h
+++ b/libeventheader-decode-cpp/include/PerfDataDecode/PerfByteReader.h
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #pragma once
-#ifndef _included_PerfDataReader_h
-#define _included_PerfDataReader_h
+#ifndef _included_PerfByteReader_h
+#define _included_PerfByteReader_h
 
 #include <stdint.h>
 #include <string.h> // memcpy
@@ -18,23 +18,28 @@
 #define _In_reads_bytes_(cb)
 #endif
 
-// Loads values from the perf file data buffer, handling misaligned
-// or byte-swapped values.
-class PerfDataReader
+// Loads values from the perf event data buffer, handling misaligned
+// and byte-swapped values.
+class PerfByteReader
 {
     bool m_bigEndian;
 
 public:
 
     // Initializes a data reader that treats input as host-endian.
-    PerfDataReader() noexcept;
+    //
+    // Postcondition: this->ByteSwapNeeded() == false.
+    PerfByteReader() noexcept;
 
     // If bigEndian is true, initializes a data reader that assumes input is
     // big-endian. Otherwise, assumes input is little-endian.
+    //
+    // Postcondition: this->BigEndian() == bigEndian.
     explicit
-    PerfDataReader(bool bigEndian) noexcept;
+    PerfByteReader(bool bigEndian) noexcept;
 
     // Returns true if this reader is treating its input data as big-endian.
+    // Returns false if this reader is treating its input data as little-endian.
     bool
     BigEndian() const noexcept;
 
@@ -111,7 +116,7 @@ public:
         else
         {
             static_assert(sizeof(ValType) == 0,
-                "PerfDataFile::Read supports values of size 1, 2, 4, and 8.");
+                "ReadAs supports values of size 1, 2, 4, and 8.");
         }
     }
 
@@ -127,4 +132,4 @@ public:
     }
 };
 
-#endif // _included_PerfDataReader_h
+#endif // _included_PerfByteReader_h

--- a/libeventheader-decode-cpp/include/PerfDataDecode/PerfDataFile.h
+++ b/libeventheader-decode-cpp/include/PerfDataDecode/PerfDataFile.h
@@ -5,7 +5,7 @@
 #ifndef _included_PerfDataFile_h
 #define _included_PerfDataFile_h
 
-#include "PerfDataReader.h"
+#include "PerfByteReader.h"
 #include <stdint.h>
 #include <stdio.h> // FILE
 #include <map>
@@ -115,7 +115,7 @@ class PerfDataFile
     std::vector<char> m_headers[32]; // Stored file-endian.
     std::vector<std::unique_ptr<perf_event_attr>> m_attrsList; // Stored host-endian.
     std::map<uint64_t, PerfEventDesc> m_eventDescById; // Points into m_attrsList and/or m_headers.
-    PerfDataReader m_dataReader;
+    PerfByteReader m_byteReader;
     int8_t m_sampleIdOffset; // -1 = unset, -2 = no id.
     int8_t m_nonSampleIdOffset; // -1 = unset, -2 = no id.
     int8_t m_commonTypeOffset; // -1 = unset, -2 = not available.
@@ -145,9 +145,9 @@ public:
     bool
     FileBigEndian() const noexcept;
 
-    // Returns PerfDataReader(FileBigEndian()).
-    PerfDataReader
-    DataReader() const noexcept;
+    // Returns PerfByteReader(FileBigEndian()).
+    PerfByteReader
+    ByteReader() const noexcept;
 
     // Returns the position within the input file of the event that will be
     // read by the next call to ReadEvent().
@@ -179,7 +179,8 @@ public:
     PerfEventDesc
     EventDescById(uint64_t id) const noexcept;
 
-    // Returns the raw data from the specified header (file-endian, use PerfDataReader).
+    // Returns the raw data from the specified header (file-endian, use ByteReader()
+    // to do byte-swapping as appropriate).
     // Returns empty if the requested header was not loaded from the file.
     std::string_view
     Header(PerfHeaderIndex headerIndex) const noexcept;
@@ -205,7 +206,7 @@ public:
     OpenStdin() noexcept;
 
     // Returns the event header (host-endian) followed by the raw data from the
-    // file (file-endian, use DataReader() to do byte-swapping as appropriate).
+    // file (file-endian, use ByteReader() to do byte-swapping as appropriate).
     //
     // On success, sets *ppEventHeader to the event and returns 0.
     // The returned pointer is valid until the next call to ReadEvent.

--- a/libeventheader-decode-cpp/src/CMakeLists.txt
+++ b/libeventheader-decode-cpp/src/CMakeLists.txt
@@ -2,9 +2,9 @@
 add_library(eventheader-decode
     EventEnumerator.cpp
     EventFormatter.cpp
+    PerfByteReader.cpp
     PerfDataAbi.cpp
     PerfDataFile.cpp
-    PerfDataReader.cpp
     PerfEventMetadata.cpp)
 target_include_directories(eventheader-decode
     PUBLIC
@@ -15,9 +15,10 @@ target_link_libraries(eventheader-decode
 set(DECODE_HEADERS
     "${PROJECT_SOURCE_DIR}/include/eventheader/EventEnumerator.h"
     "${PROJECT_SOURCE_DIR}/include/eventheader/EventFormatter.h"
+    "${PROJECT_SOURCE_DIR}/include/PerfDataDecode/PerfByteReader.h"
     "${PROJECT_SOURCE_DIR}/include/PerfDataDecode/PerfDataAbi.h"
     "${PROJECT_SOURCE_DIR}/include/PerfDataDecode/PerfDataFile.h"
-    "${PROJECT_SOURCE_DIR}/include/PerfDataDecode/PerfDataReader.h"
+    "${PROJECT_SOURCE_DIR}/include/PerfDataDecode/PerfEventInfo.h"
     "${PROJECT_SOURCE_DIR}/include/PerfDataDecode/PerfEventMetadata.h")
 set_target_properties(eventheader-decode PROPERTIES
     PUBLIC_HEADER "${DECODE_HEADERS}")

--- a/libeventheader-decode-cpp/src/EventFormatter.cpp
+++ b/libeventheader-decode-cpp/src/EventFormatter.cpp
@@ -4,7 +4,7 @@
 #include <eventheader/EventFormatter.h>
 #include <PerfDataDecode/PerfEventMetadata.h>
 #include <PerfDataDecode/PerfEventInfo.h>
-#include <PerfDataDecode/PerfDataReader.h>
+#include <PerfDataDecode/PerfByteReader.h>
 #include <PerfDataDecode/PerfDataAbi.h>
 
 #include <assert.h>
@@ -1705,7 +1705,7 @@ AppendIntegerSampleFieldAsJsonImpl(
     char const* format64)
 {
     assert(sb.Room() > 0);
-    PerfDataReader const dataReader(fileBigEndian);
+    PerfByteReader const byteReader(fileBigEndian);
 
     if (fieldMetadata.Array() == PerfFieldArrayNone)
     {
@@ -1720,7 +1720,7 @@ AppendIntegerSampleFieldAsJsonImpl(
             {
                 unsigned const RoomNeeded = 6; // ["0xFF"]
                 sb.EnsureRoom(RoomNeeded);
-                auto val = dataReader.ReadAsU8(fieldRawData.data());
+                auto val = byteReader.ReadAsU8(fieldRawData.data());
                 sb.WritePrintf(RoomNeeded, format32, val);
             }
             break;
@@ -1733,7 +1733,7 @@ AppendIntegerSampleFieldAsJsonImpl(
             {
                 unsigned const RoomNeeded = 8; // ["0xFFFF"]
                 sb.EnsureRoom(RoomNeeded);
-                auto val = dataReader.ReadAsU16(fieldRawData.data());
+                auto val = byteReader.ReadAsU16(fieldRawData.data());
                 sb.WritePrintf(RoomNeeded, format32, val);
             }
             break;
@@ -1746,7 +1746,7 @@ AppendIntegerSampleFieldAsJsonImpl(
             {
                 unsigned const RoomNeeded = 12; // ["0xFFFFFFFF"]
                 sb.EnsureRoom(RoomNeeded);
-                auto val = dataReader.ReadAsU32(fieldRawData.data());
+                auto val = byteReader.ReadAsU32(fieldRawData.data());
                 sb.WritePrintf(RoomNeeded, format32, val);
             }
             break;
@@ -1759,7 +1759,7 @@ AppendIntegerSampleFieldAsJsonImpl(
             {
                 unsigned const RoomNeeded = 20; // ["0xFFFFFFFFFFFFFFFF"]
                 sb.EnsureRoom(RoomNeeded);
-                auto val = dataReader.ReadAsU64(fieldRawData.data());
+                auto val = byteReader.ReadAsU64(fieldRawData.data());
                 sb.WritePrintf(RoomNeeded, format64, val);
             }
             break;
@@ -1779,7 +1779,7 @@ AppendIntegerSampleFieldAsJsonImpl(
                 unsigned const RoomNeeded = 6; // ["0xFF"]
                 sb.EnsureRoom(RoomNeeded + 2);
                 sb.WriteJsonCommaSpaceAsNeeded();
-                sb.WritePrintf(RoomNeeded, format32, dataReader.Read(p));
+                sb.WritePrintf(RoomNeeded, format32, byteReader.Read(p));
             }
             break;
         case PerfFieldElementSize16:
@@ -1788,7 +1788,7 @@ AppendIntegerSampleFieldAsJsonImpl(
                 unsigned const RoomNeeded = 8; // ["0xFFFF"]
                 sb.EnsureRoom(RoomNeeded + 2);
                 sb.WriteJsonCommaSpaceAsNeeded();
-                sb.WritePrintf(RoomNeeded, format32, dataReader.Read(p));
+                sb.WritePrintf(RoomNeeded, format32, byteReader.Read(p));
             }
             break;
         case PerfFieldElementSize32:
@@ -1797,7 +1797,7 @@ AppendIntegerSampleFieldAsJsonImpl(
                 unsigned const RoomNeeded = 12; // ["0xFFFFFFFF"]
                 sb.EnsureRoom(RoomNeeded + 2);
                 sb.WriteJsonCommaSpaceAsNeeded();
-                sb.WritePrintf(RoomNeeded, format32, dataReader.Read(p));
+                sb.WritePrintf(RoomNeeded, format32, byteReader.Read(p));
             }
             break;
         case PerfFieldElementSize64:
@@ -1806,7 +1806,7 @@ AppendIntegerSampleFieldAsJsonImpl(
                 unsigned const RoomNeeded = 20; // ["0xFFFFFFFFFFFFFFFF"]
                 sb.EnsureRoom(RoomNeeded + 2);
                 sb.WriteJsonCommaSpaceAsNeeded();
-                sb.WritePrintf(RoomNeeded, format64, dataReader.Read(p));
+                sb.WritePrintf(RoomNeeded, format64, byteReader.Read(p));
             }
             break;
         }
@@ -1826,7 +1826,7 @@ AppendSampleFieldAsJsonImpl(
     bool fileBigEndian,
     bool wantName)
 {
-    PerfDataReader const dataReader(fileBigEndian);
+    PerfByteReader const byteReader(fileBigEndian);
     auto const fieldRawDataChars = static_cast<char const*>(fieldRawData);
 
     // Note: AppendIntegerSampleFieldAsJsonImpl expects 1 byte reserved for '['.
@@ -1940,7 +1940,7 @@ EventFormatter::AppendSampleAsJson(
     {
     NotEventHeader:
 
-        PerfDataReader const dataReader(fileBigEndian);
+        PerfByteReader const byteReader(fileBigEndian);
         auto const sampleEventNameColon = strchr(sampleEventInfo.name, ':');
         eventInfoValid = false;
         sampleEventName = sampleEventNameColon ? sampleEventNameColon + 1 : "";

--- a/libeventheader-decode-cpp/src/PerfByteReader.cpp
+++ b/libeventheader-decode-cpp/src/PerfByteReader.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <PerfDataDecode/PerfDataReader.h>
+#include <PerfDataDecode/PerfByteReader.h>
 #include <string.h>
 #include <assert.h>
 
@@ -17,32 +17,32 @@ static bool constexpr HostIsBigEndian = false;
 static bool constexpr HostIsBigEndian = __BYTE_ORDER == __BIG_ENDIAN;
 #endif // _WIN32
 
-PerfDataReader::PerfDataReader() noexcept
+PerfByteReader::PerfByteReader() noexcept
     : m_bigEndian(HostIsBigEndian) {}
 
-PerfDataReader::PerfDataReader(bool bigEndian) noexcept
+PerfByteReader::PerfByteReader(bool bigEndian) noexcept
     : m_bigEndian(bigEndian) {}
 
 bool
-PerfDataReader::BigEndian() const noexcept
+PerfByteReader::BigEndian() const noexcept
 {
     return m_bigEndian;
 }
 
 bool
-PerfDataReader::ByteSwapNeeded() const noexcept
+PerfByteReader::ByteSwapNeeded() const noexcept
 {
     return HostIsBigEndian != m_bigEndian;
 }
 
 uint8_t
-PerfDataReader::ReadAsU8(_In_reads_bytes_(1) void const* pSrc) const noexcept
+PerfByteReader::ReadAsU8(_In_reads_bytes_(1) void const* pSrc) const noexcept
 {
     return *static_cast<uint8_t const*>(pSrc);
 }
 
 uint16_t
-PerfDataReader::ReadAsU16(_In_reads_bytes_(2) void const* pSrc) const noexcept
+PerfByteReader::ReadAsU16(_In_reads_bytes_(2) void const* pSrc) const noexcept
 {
     uint16_t fileBits;
     memcpy(&fileBits, pSrc, sizeof(fileBits));
@@ -50,7 +50,7 @@ PerfDataReader::ReadAsU16(_In_reads_bytes_(2) void const* pSrc) const noexcept
 }
 
 uint32_t
-PerfDataReader::ReadAsU32(_In_reads_bytes_(4) void const* pSrc) const noexcept
+PerfByteReader::ReadAsU32(_In_reads_bytes_(4) void const* pSrc) const noexcept
 {
     uint32_t fileBits;
     memcpy(&fileBits, pSrc, sizeof(fileBits));
@@ -58,7 +58,7 @@ PerfDataReader::ReadAsU32(_In_reads_bytes_(4) void const* pSrc) const noexcept
 }
 
 uint64_t
-PerfDataReader::ReadAsU64(_In_reads_bytes_(8) void const* pSrc) const noexcept
+PerfByteReader::ReadAsU64(_In_reads_bytes_(8) void const* pSrc) const noexcept
 {
     uint64_t fileBits;
     memcpy(&fileBits, pSrc, sizeof(fileBits));
@@ -66,7 +66,7 @@ PerfDataReader::ReadAsU64(_In_reads_bytes_(8) void const* pSrc) const noexcept
 }
 
 uint32_t
-PerfDataReader::ReadAsDynU32(
+PerfByteReader::ReadAsDynU32(
     _In_reads_bytes_(cbSrc) void const* pSrc,
     uint8_t cbSrc) const noexcept
 {
@@ -91,7 +91,7 @@ PerfDataReader::ReadAsDynU32(
 }
 
 uint64_t
-PerfDataReader::ReadAsDynU64(
+PerfByteReader::ReadAsDynU64(
     _In_reads_bytes_(cbSrc) void const* pSrc,
     uint8_t cbSrc) const noexcept
 {

--- a/libeventheader-decode-cpp/src/PerfEventMetadata.cpp
+++ b/libeventheader-decode-cpp/src/PerfEventMetadata.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include <PerfDataDecode/PerfEventMetadata.h>
-#include <PerfDataDecode/PerfDataReader.h>
+#include <PerfDataDecode/PerfByteReader.h>
 #include <assert.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -626,7 +626,7 @@ PerfFieldMetadata::GetFieldBytes(
     bool fileBigEndian) const noexcept
 {
     std::string_view result;
-    PerfDataReader const dataReader(fileBigEndian);
+    PerfByteReader const byteReader(fileBigEndian);
     auto const eventRawDataChars = static_cast<char const*>(eventRawData);
 
     if (static_cast<size_t>(m_offset) + m_size <= eventRawDataSize)
@@ -647,7 +647,7 @@ PerfFieldMetadata::GetFieldBytes(
             if (m_size == 4)
             {
                 // 4-byte value is an offset/length pair leading to the real data.
-                auto const dyn = dataReader.ReadAsU32(eventRawDataChars + m_offset);
+                auto const dyn = byteReader.ReadAsU32(eventRawDataChars + m_offset);
                 auto const dynSize = dyn >> 16;
                 auto dynOffset = dyn & 0xFFFF;
                 if (m_array == PerfFieldArrayRelDyn)
@@ -664,7 +664,7 @@ PerfFieldMetadata::GetFieldBytes(
             else if (m_size == 2)
             {
                 // 2-byte value is an offset leading to the real data, size is strlen.
-                size_t dynOffset = dataReader.ReadAsU16(eventRawDataChars + m_offset);
+                size_t dynOffset = byteReader.ReadAsU16(eventRawDataChars + m_offset);
                 if (m_array == PerfFieldArrayRelDyn)
                 {
                     // offset is relative to end of field.


### PR DESCRIPTION
PerfDataReader sounds like it's a parser for perf.data files, but it isn't. It's just the byteswapper helper used by this Perf helper library. Rename it to PerfByteReader in hopes that's a little bit less confusing.

Also add a line to the CMakeLists.txt for the recently-added PerfEventInfo.h header (should have been added in the previous commit).