### PR TITLE
Rename PerfDataAbi.h to PerfEventAbi.h

### DIFF
--- a/libeventheader-decode-cpp/src/EventFormatter.cpp
+++ b/libeventheader-decode-cpp/src/EventFormatter.cpp
@@ -5,7 +5,7 @@
 #include <tracepoint/PerfEventMetadata.h>
 #include <tracepoint/PerfEventInfo.h>
 #include <tracepoint/PerfByteReader.h>
-#include <tracepoint/PerfDataAbi.h>
+#include <tracepoint/PerfEventAbi.h>
 
 #include <assert.h>
 #include <math.h>

--- a/libeventheader-decode-cpp/tools/decode-perf.cpp
+++ b/libeventheader-decode-cpp/tools/decode-perf.cpp
@@ -3,7 +3,7 @@
 
 #include <tracepoint/PerfEventInfo.h>
 #include <tracepoint/PerfDataFile.h>
-#include <tracepoint/PerfDataAbi.h>
+#include <tracepoint/PerfEventAbi.h>
 #include <eventheader/EventFormatter.h>
 
 #include <string.h>

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfDataFile.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfDataFile.h
@@ -51,7 +51,7 @@ struct PerfNonSampleEventInfo;
 // Forward declaration from PerfEventMetadata.h:
 class PerfEventMetadata;
 
-// Forward declarations from PerfDataAbi.h or linux/uapi/linux/perf_event.h:
+// Forward declarations from PerfEventAbi.h or linux/uapi/linux/perf_event.h:
 struct perf_event_attr;
 struct perf_event_header;
 

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventAbi.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventAbi.h
@@ -3,8 +3,8 @@
 // Adapted from linux/uapi/linux/perf_event.h.
 
 #pragma once
-#ifndef _included_PerfDataAbi_h
-#define _included_PerfDataAbi_h
+#ifndef _included_PerfEventAbi_h
+#define _included_PerfEventAbi_h
 
 #include <stdint.h>
 
@@ -759,4 +759,4 @@ PerfEnumToString(perf_type_id value, _Pre_cap_(11) char* scratch) noexcept;
 _Ret_z_ char const*
 PerfEnumToString(perf_event_type value, _Pre_cap_(11) char* scratch) noexcept;
 
-#endif // _included_PerfDataAbi_h
+#endif // _included_PerfEventAbi_h

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
@@ -20,7 +20,7 @@
 // Forward declaration from PerfEventMetadata.h:
 class PerfEventMetadata;
 
-// Forward declaration from PerfDataAbi.h or linux/uapi/linux/perf_event.h:
+// Forward declaration from PerfEventAbi.h or linux/uapi/linux/perf_event.h:
 struct perf_event_attr;
 
 struct PerfSampleEventInfo

--- a/libtracepoint-decode-cpp/src/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 # tracepoint-decode = libtracepoint-decode, DECODE_HEADERS
 add_library(tracepoint-decode
     PerfByteReader.cpp
-    PerfDataAbi.cpp
     PerfDataFile.cpp
+    PerfEventAbi.cpp
     PerfEventMetadata.cpp)
 target_include_directories(tracepoint-decode
     PUBLIC
@@ -10,8 +10,8 @@ target_include_directories(tracepoint-decode
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 set(DECODE_HEADERS
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfByteReader.h"
-    "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfDataAbi.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfDataFile.h"
+    "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventAbi.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventInfo.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventMetadata.h")
 set_target_properties(tracepoint-decode PROPERTIES

--- a/libtracepoint-decode-cpp/src/PerfDataFile.cpp
+++ b/libtracepoint-decode-cpp/src/PerfDataFile.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include <tracepoint/PerfDataFile.h>
-#include <tracepoint/PerfDataAbi.h>
+#include <tracepoint/PerfEventAbi.h>
 #include <tracepoint/PerfEventMetadata.h>
 #include <tracepoint/PerfEventInfo.h>
 

--- a/libtracepoint-decode-cpp/src/PerfEventAbi.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventAbi.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <tracepoint/PerfDataAbi.h>
+#include <tracepoint/PerfEventAbi.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
PerfDataAbi.h contains the Linux structure definitions needed for parsing `perf.data` files on Windows. Originally, it contained definitions from various different sources so it was reasonable to name it based on the goal of parsing perf.data. However, after cleanup, it ends up containing only definitions adapted from the Linux `perf_event.h` header, so it seems better to give it a name reflecting the original source, so name it `PerfEventAbi.h`.