### PR TITLE
Namespaces for the C++ decode libraries

### DIFF
--- a/libeventheader-decode-cpp/include/eventheader/EventEnumerator.h
+++ b/libeventheader-decode-cpp/include/eventheader/EventEnumerator.h
@@ -28,642 +28,646 @@
 #define _Field_size_bytes_opt_(cb)
 #endif
 
-// Forward declarations:
-class EventEnumerator;
-enum EventEnumeratorState : uint8_t;
-enum EventEnumeratorError : uint8_t;
-struct EventInfo;
-struct EventItemInfo;
-struct EventDataPosition;
-
-/// <summary>
-/// Helper for decoding EventHeader events.
-/// </summary>
-class EventEnumerator
+namespace eventheader_decode
 {
-    static event_field_encoding const EncodingCountMask = static_cast<event_field_encoding>(
-        event_field_encoding_carray_flag | event_field_encoding_varray_flag);
-
-    static event_field_encoding const ReadFieldError = event_field_encoding_invalid;
+    // Forward declarations:
+    class EventEnumerator;
+    enum EventEnumeratorState : uint8_t;
+    enum EventEnumeratorError : uint8_t;
+    struct EventInfo;
+    struct EventItemInfo;
+    struct EventDataPosition;
 
     /// <summary>
-    /// Substate allows us to flatten
-    /// "switch (state)    { case X: if (condition) ... }" to
-    /// "switch (substate) { case X_condition: ... }"
-    /// which potentially improves performance.
+    /// Helper for decoding EventHeader events.
     /// </summary>
-    enum SubState : uint8_t
+    class EventEnumerator
     {
-        SubState_None,
-        SubState_Error,
-        SubState_AfterLastItem,
-        SubState_BeforeFirstItem,
-        SubState_Value_Metadata,
-        SubState_Value_Scalar,
-        SubState_Value_SimpleArrayElement,
-        SubState_Value_ComplexArrayElement,
-        SubState_ArrayBegin,
-        SubState_ArrayEnd,
-        SubState_StructBegin,
-        SubState_StructEnd,
+        static event_field_encoding const EncodingCountMask = static_cast<event_field_encoding>(
+            event_field_encoding_carray_flag | event_field_encoding_varray_flag);
+
+        static event_field_encoding const ReadFieldError = event_field_encoding_invalid;
+
+        /// <summary>
+        /// Substate allows us to flatten
+        /// "switch (state)    { case X: if (condition) ... }" to
+        /// "switch (substate) { case X_condition: ... }"
+        /// which potentially improves performance.
+        /// </summary>
+        enum SubState : uint8_t
+        {
+            SubState_None,
+            SubState_Error,
+            SubState_AfterLastItem,
+            SubState_BeforeFirstItem,
+            SubState_Value_Metadata,
+            SubState_Value_Scalar,
+            SubState_Value_SimpleArrayElement,
+            SubState_Value_ComplexArrayElement,
+            SubState_ArrayBegin,
+            SubState_ArrayEnd,
+            SubState_StructBegin,
+            SubState_StructEnd,
+        };
+
+        struct StackEntry
+        {
+            uint16_t NextOffset; // m_metaBuf[NextOffset] starts next field's name.
+            uint16_t NameOffset; // m_metaBuf[NameOffset] starts current field's name.
+            uint16_t NameSize;   // m_metaBuf[NameOffset + NameSize + 1] starts current field's type.
+            uint16_t ArrayIndex;
+            uint16_t ArrayCount;
+            uint8_t  RemainingFieldCount; // Number of NextProperty() calls before popping stack.
+            uint8_t  ArrayFlags; // Encoding & EncodingCountMask
+        };
+
+        struct FieldType
+        {
+            event_field_encoding Encoding : 8;
+            event_field_format   Format : 8;
+            unsigned Tag : 16;
+        };
+
+    private:
+
+        // Set up by StartEvent:
+        eventheader m_header;
+        uint64_t m_keyword;
+        uint8_t const* m_metaBuf;
+        uint8_t const* m_dataBuf;
+        uint8_t const* m_activityIdBuf;
+        char const* m_tracepointName; // Not nul-terminated.
+        uint8_t m_tracepointNameLength;
+        uint8_t m_providerNameLength; // Index into m_tracepointName
+        uint8_t m_optionsIndex; // Index into m_tracepointName
+        uint16_t m_metaEnd;
+        uint8_t m_activityIdSize;
+        bool m_needByteSwap;
+        uint16_t m_eventNameSize; // Name starts at m_metaBuf
+        uint32_t m_dataEnd;
+
+        // Values change during enumeration:
+        uint32_t m_dataPosRaw;
+        uint32_t m_moveNextRemaining;
+        StackEntry m_stackTop;
+        uint8_t m_stackIndex; // Number of items currently on stack.
+        EventEnumeratorState m_state;
+        SubState m_subState;
+        EventEnumeratorError m_lastError;
+
+        uint8_t m_elementSize; // 0 if item is variable-size or complex.
+        FieldType m_fieldType; // Note: fieldType.Encoding is cooked.
+        uint32_t m_dataPosCooked;
+        uint32_t m_itemSizeRaw;
+        uint32_t m_itemSizeCooked;
+
+        // Limit events to 8 levels of nested structures.
+        StackEntry m_stack[8];
+
+    public:
+
+        static uint32_t const MoveNextLimitDefault = 4096;
+
+        /// <summary>
+        /// Initializes a new instance of EventEnumerator. Sets State to None.
+        /// </summary>
+        EventEnumerator() noexcept;
+
+        /// <summary>
+        /// Returns the current state.
+        /// </summary>
+        EventEnumeratorState
+        State() const noexcept;
+
+        /// <summary>
+        /// Gets status for the most recent call to StartEvent, MoveNext, or MoveNextSibling.
+        /// </summary>
+        EventEnumeratorError
+        LastError() const noexcept;
+
+        /// <summary>
+        /// Sets State to None.
+        /// </summary>
+        void
+        Clear() noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Starts decoding the specified EventHeader event: decodes the header and
+        /// positions the enumerator before the first item.
+        /// </para><para>
+        /// On success, changes the state to BeforeFirstItem and returns true.
+        /// On failure, changes the state to None (not Error) and returns false.
+        /// </para><para>
+        /// Note that the enumerator stores the pchTracepointName and pData pointers but
+        /// does not copy the referenced data, so the referenced data must remain valid
+        /// and unchanged while you are processing the data with this enumerator (i.e.
+        /// do not deallocate or overwrite the name or data until you call Clear, make
+        /// another call to StartEvent, or destroy this EventEnumerator instance).
+        /// </para>
+        /// </summary>
+        /// <param name="pchTracepointName">Set to tep_event->name, e.g. "MyProvider_L4K1".
+        /// Must follow the tracepoint name rules described in eventheader.h.</param>
+        /// <param name="cchTracepointName">Set to strlen(tep_event->name). Must be less
+        /// than EVENTHEADER_NAME_MAX.</param>
+        /// <param name="pData">Set to pointer to the start of the event data (the eventheader_flags
+        /// field of the event header), usually something like
+        /// tep_record->data + tep_event->format.fields[0].offset.</param>
+        /// <param name="cbData">Set to size of the data, usually something like
+        /// tep_record->size - tep_event->format.fields[0].offset.</param>
+        /// <param name="moveNextLimit">Set to the maximum number of MoveNext calls to allow when
+        /// processing this event (to guard against DoS attacks from a maliciously-crafted
+        /// event).</param>
+        /// <returns>Returns false for failure. Check LastError for details.</returns>
+        bool
+        StartEvent(
+            _In_reads_bytes_(cchTracepointName) char const* pchTracepointName, // e.g. "MyProvider_L4K1"
+            size_t cchTracepointName, // e.g. strlen(pchTracepointName)
+            _In_reads_bytes_(cbData) void const* pData, // points at the eventheader_flags field
+            size_t cbData, // size in bytes of the pData buffer
+            uint32_t moveNextLimit = MoveNextLimitDefault) noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Positions the enumerator before the first item.
+        /// </para><para>
+        /// PRECONDITION: Can be called when State != None, i.e. at any time after a
+        /// successful call to StartEvent, until a call to Clear.
+        /// </para>
+        /// </summary>
+        void
+        Reset(uint32_t moveNextLimit = MoveNextLimitDefault) noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Moves the enumerator to the next item in the current event, or to the end
+        /// of the event if no more items. Returns true if moved to a valid item,
+        /// false if no more items or decoding error.
+        /// </para><para>
+        /// PRECONDITION: Can be called when State >= BeforeFirstItem, i.e. after a
+        /// successful call to StartEvent, until MoveNext returns false.
+        /// </para><para>
+        /// Typically called in a loop until it returns false, e.g.:
+        /// </para><code>
+        /// if (!e.StartEvent(...)) return e.LastError();
+        /// while (e.MoveNext())
+        /// {
+        ///     EventItemInfo item = e.GetItemInfo();
+        ///     switch (e.State())
+        ///     {
+        ///     case EventEnumeratorState_Value:
+        ///         DoValue(item);
+        ///         break;
+        ///     case EventEnumeratorState_StructBegin:
+        ///         DoStructBegin(item);
+        ///         break;
+        ///     case EventEnumeratorState_StructEnd:
+        ///         DoStructEnd(item);
+        ///         break;
+        ///     case EventEnumeratorState_ArrayBegin:
+        ///         DoArrayBegin(item);
+        ///         break;
+        ///     case EventEnumeratorState_ArrayEnd:
+        ///         DoArrayEnd(item);
+        ///         break;
+        ///     }
+        /// }
+        /// return e.LastError();
+        /// </code>
+        /// </summary>
+        /// <returns>
+        /// Returns true if moved to a valid item.
+        /// Returns false and sets state to AfterLastItem if no more items.
+        /// Returns false and sets state to Error for decoding error.
+        /// Check LastError for details.
+        /// </returns>
+        bool
+        MoveNext() noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Moves the enumerator to the next sibling of the current item, or to the end
+        /// of the event if no more items. Returns true if moved to a valid item, false
+        /// if no more items or decoding error.
+        /// </para><para>
+        /// PRECONDITION: Can be called when State >= BeforeFirstItem, i.e. after a
+        /// successful call to StartEvent, until MoveNext returns false.
+        /// </para><list type="bullet"><item>
+        /// If the current item is ArrayBegin or StructBegin, this efficiently moves
+        /// enumeration to AFTER the corresponding ArrayEnd or StructEnd.
+        /// </item><item>
+        /// Otherwise, this is the same as MoveNext.
+        /// </item></list><para>
+        /// Typical use for this method is to efficiently skip past an array of fixed-size
+        /// items (i.e. an array where ElementSize is nonzero) when you process all of the
+        /// array items within the ArrayBegin state.
+        /// </para><code>
+        /// if (!e.StartEvent(...)) return e.LastError(); // Error.
+        /// if (!e.MoveNext()) return e.LastError(); // AfterLastItem or Error.
+        /// while (true)
+        /// {
+        ///     EventItemInfo item = e.GetItemInfo();
+        ///     switch (e.State())
+        ///     {
+        ///     case EventEnumeratorState_Value:
+        ///         DoValue(item);
+        ///         break;
+        ///     case EventEnumeratorState_StructBegin:
+        ///         DoStructBegin(item);
+        ///         break;
+        ///     case EventEnumeratorState_StructEnd:
+        ///         DoStructEnd(item);
+        ///         break;
+        ///     case EventEnumeratorState_ArrayBegin:
+        ///         if (e.ElementSize == 0)
+        ///         {
+        ///             DoComplexArrayBegin(item);
+        ///         }
+        ///         else
+        ///         {
+        ///             // Process the entire array directly without using the enumerator.
+        ///             DoSimpleArrayBegin(item);
+        ///             for (unsigned i = 0; i != item.ArrayCount; i++)
+        ///             {
+        ///                 DoArrayElement(item, i);
+        ///             }
+        ///             DoSimpleArrayEnd(item);
+        /// 
+        ///             // Skip the entire array at once.
+        ///             if (!e.MoveNextSibling()) // Instead of MoveNext().
+        ///             {
+        ///                 return e.LastError(); // AfterLastItem or Error.
+        ///             }
+        ///             continue; // Skip the MoveNext().
+        ///         }
+        ///         break;
+        ///     case EventEnumeratorState_ArrayEnd:
+        ///         DoComplexArrayEnd(item);
+        ///         break;
+        ///     }
+        ///
+        ///     if (!e.MoveNext())
+        ///     {
+        ///         return e.LastError(); // AfterLastItem or Error.
+        ///     }
+        /// }
+        /// </code>
+        /// </summary>
+        /// <returns>
+        /// Returns true if moved to a valid item.
+        /// Returns false and sets state to AfterLastItem if no more items.
+        /// Returns false and sets state to Error for decoding error.
+        /// Check LastError for details.
+        /// </returns>
+        bool
+        MoveNextSibling() noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Advanced scenarios. This method is for extracting type information from an
+        /// event without looking at value information. Moves the enumerator to the next
+        /// field declaration (not the next field value). Returns true if moved to a valid
+        /// item, false if no more items or decoding error.
+        /// </para><para>
+        /// PRECONDITION: Can be called after a successful call to StartEvent, until
+        /// MoveNextMetadata returns false.
+        /// </para><para>
+        /// Note that metadata enumeration gives a flat view of arrays and structures.
+        /// There are only Value items, no BeginArray, EndArray, BeginStruct, EndStruct.
+        /// A struct shows up as a value with Encoding = Struct (Format holds field count).
+        /// An array shows up as a value with ArrayFlags != 0, and ArrayCount is either zero
+        /// (indicating a runtime-variable array length) or nonzero (indicating a compile-time
+        /// constant array length). An array of struct is a field with Encoding = Struct and
+        /// ArrayFlags != 0. ValueBytes will always be empty. ArrayIndex and ElementSize
+        /// will always be zero.
+        /// </para><para>
+        /// Note that when enumerating metadata for a structure, the enumeration may end before
+        /// the expected number of fields are seen. This is a supported scenario and is not an
+        /// error in the event. A large field count just means "this structure contains all the
+        /// remaining fields in the event".
+        /// </para><para>
+        /// Typically called in a loop until it returns false.
+        /// </para><code>
+        /// if (!e.StartEvent(...)) return e.LastError();
+        /// while (e.MoveNextMetadata())
+        /// {
+        ///     DoFieldDeclaration(e.GetItemInfo());
+        /// }
+        /// return e.LastError();
+        /// </code>
+        /// </summary>
+        /// <returns>
+        /// Returns true if moved to a valid item.
+        /// Returns false and sets state to AfterLastItem if no more items.
+        /// Returns false and sets state to Error for decoding error.
+        /// Check LastError for details.
+        /// </returns>
+        bool
+        MoveNextMetadata() noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Gets information that applies to the current event, e.g. the event name,
+        /// provider name, options, level, keyword, etc.
+        /// </para><para>
+        /// PRECONDITION: Can be called when State != None, i.e. at any time after a
+        /// successful call to StartEvent, until a call to Clear.
+        /// </para>
+        /// </summary>
+        EventInfo
+        GetEventInfo() const noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Gets information that applies to the current item, e.g. the item's name,
+        /// the item's type (integer, string, float, etc.), data pointer, data size.
+        /// The current item changes each time MoveNext() is called.
+        /// </para><para>
+        /// PRECONDITION: Can be called when State > BeforeFirstItem, i.e. after MoveNext
+        /// returns true.
+        /// </para>
+        /// </summary>
+        EventItemInfo
+        GetItemInfo() const noexcept;
+
+        /// <summary>
+        /// <para>
+        /// Gets the remaining event payload, i.e. the event data that has not yet
+        /// been decoded. The data position can change each time MoveNext is called.
+        /// </para><para>
+        /// PRECONDITION: Can be called when State != None, i.e. at any time after a
+        /// successful call to StartEvent, until a call to Clear.
+        /// </para><para>
+        /// This can be useful after enumeration has completed to to determine
+        /// whether the event contains any trailing data (data not described by the
+        /// decoding information). Up to 3 bytes of trailing data is normal (padding
+        /// between events), but 4 or more bytes of trailing data might indicate some
+        /// kind of encoding problem or data corruption.
+        /// </para>
+        /// </summary>
+        EventDataPosition
+        GetRawDataPosition() const noexcept;
+
+    private:
+
+        void
+        ResetImpl(uint32_t moveNextLimit) noexcept;
+
+        bool
+        SkipStructMetadata() noexcept;
+
+        bool
+        NextProperty() noexcept;
+
+        /// <summary>
+        /// Requires m_metaEnd >= m_stackTop.NameOffset.
+        /// Reads name, encoding, format, tag starting at m_stackTop.NameOffset.
+        /// Updates m_stackTop.NameSize, m_stackTop.NextOffset.
+        /// On failure, returns Encoding = None.
+        /// </summary>
+        FieldType
+        ReadFieldNameAndType() noexcept;
+
+        /// <summary>
+        /// Requires m_metaEnd > typeOffset.
+        /// Reads encoding, format, tag starting at m_stackTop.NameOffset.
+        /// Updates m_stackTop.NextOffset.
+        /// On failure, returns Encoding = None.
+        /// </summary>
+        FieldType
+        ReadFieldType(uint16_t typeOffset) noexcept;
+
+        bool
+        StartArray() noexcept;
+
+        void
+        StartStruct() noexcept;
+
+        bool
+        StartValue() noexcept;
+
+        void
+        StartValueSimple() noexcept;
+
+        template<class CH>
+        void
+        StartValueStringNul() noexcept;
+
+        void
+        StartValueStringLength16(uint8_t charSizeShift) noexcept;
+
+        void
+        SetState(EventEnumeratorState newState, SubState newSubState) noexcept;
+
+        void
+        SetEndState(EventEnumeratorState newState, SubState newSubState) noexcept;
+
+        bool
+        SetNoneState(EventEnumeratorError error) noexcept;
+
+        bool
+        SetErrorState(EventEnumeratorError error) noexcept;
     };
 
-    struct StackEntry
+    /// <summary>
+    /// Enumeration states.
+    /// </summary>
+    enum EventEnumeratorState : uint8_t
     {
-        uint16_t NextOffset; // m_metaBuf[NextOffset] starts next field's name.
-        uint16_t NameOffset; // m_metaBuf[NameOffset] starts current field's name.
-        uint16_t NameSize;   // m_metaBuf[NameOffset + NameSize + 1] starts current field's type.
+        /// <summary>
+        /// After construction, a call to Clear, or a failed StartEvent.
+        /// </summary>
+        EventEnumeratorState_None,
+
+        /// <summary>
+        /// After an error has been returned by MoveNext.
+        /// </summary>
+        EventEnumeratorState_Error,
+
+        /// <summary>
+        /// Positioned after the last item in the event.
+        /// </summary>
+        EventEnumeratorState_AfterLastItem,
+
+        // MoveNext() is an invalid operation for all states above this line.
+        // MoveNext() is a valid operation for all states below this line.
+
+        /// <summary>
+        /// Positioned before the first item in the event.
+        /// </summary>
+        EventEnumeratorState_BeforeFirstItem,
+
+        // GetItemInfo() is an invalid operation for all states above this line.
+        // GetItemInfo() is a valid operation for all states below this line.
+
+        /// <summary>
+        /// Positioned at an item with data (a field or an array element).
+        /// </summary>
+        EventEnumeratorState_Value,
+
+        /// <summary>
+        /// Positioned before the first item in an array.
+        /// </summary>
+        EventEnumeratorState_ArrayBegin,
+
+        /// <summary>
+        /// Positioned after the last item in an array.
+        /// </summary>
+        EventEnumeratorState_ArrayEnd,
+
+        /// <summary>
+        /// Positioned before the first item in a struct.
+        /// </summary>
+        EventEnumeratorState_StructBegin,
+
+        /// <summary>
+        /// Positioned after the last item in a struct.
+        /// </summary>
+        EventEnumeratorState_StructEnd,
+    };
+
+    /// <summary>
+    /// Values for the LastError property.
+    /// </summary>
+    enum EventEnumeratorError : uint8_t
+    {
+        /// <summary>
+        /// No error.
+        /// </summary>
+        EventEnumeratorError_Success = 0,
+
+        /// <summary>
+        /// Event is smaller than 8 bytes or larger than 2GB,
+        /// or TracepointName is longer than 255 characters.
+        /// </summary>
+        EventEnumeratorError_InvalidParameter = EINVAL,
+
+        /// <summary>
+        /// Event does not follow the EventHeader naming/layout rules,
+        /// is big-endian, has unrecognized flags, or unrecognized types.
+        /// </summary>
+        EventEnumeratorError_NotSupported = ENOTSUP,
+
+        /// <summary>
+        /// Resource usage limit (moveNextLimit) reached.
+        /// </summary>
+        EventEnumeratorError_ImplementationLimit = E2BIG,
+
+        /// <summary>
+        /// Event has an out-of-range value.
+        /// </summary>
+        EventEnumeratorError_InvalidData = EBADMSG,
+
+        /// <summary>
+        /// Event has more than 8 levels of nested structs.
+        /// </summary>
+        EventEnumeratorError_StackOverflow = EOVERFLOW,
+
+        /// <summary>
+        /// Method call invalid for current State().
+        /// </summary>
+        EventEnumeratorError_InvalidState = EPERM,
+    };
+
+    struct EventDataPosition
+    {
+        _Field_size_bytes_(Size) void const* Data;
+        uint32_t Size;
+    };
+
+    struct EventInfo
+    {
+        // "EventName" followed by 0 or more event attributes.
+        // Each attribute is ";AttribName=AttribValue".
+        // EventName should not contain ';'.
+        // AttribName should not contain ';' or '='.
+        // AttribValue may contain ";;" which should be unescaped to ";".
+        _Field_z_ char const* Name;
+
+        // TracepointName, e.g. "ProviderName_LnKnnnOptions".
+        // May not be nul-terminated. Length is TracepointNameLength.
+        _Field_size_bytes_(TracepointNameLength) char const* TracepointName;
+
+        // 128-bit big-endian activity id, or NULL if none.
+        _Field_size_bytes_opt_(16) uint8_t const* ActivityId;
+
+        // 128-bit big-endian related activity id, or NULL if none.
+        _Field_size_bytes_opt_(16) uint8_t const* RelatedActivityId;
+
+        // flags, version, id, tag, opcode, level.
+        eventheader Header;
+
+        // Event category bits.
+        uint64_t Keyword;
+
+        // Length of TracepointName.
+        uint8_t TracepointNameLength;
+
+        // Length of the ProviderName part of TracepointName, e.g. if
+        // TracepointName is "ProviderName_LnKnnnOptions", this will be 12
+        // since strlen("ProviderName") = 12.
+        uint8_t ProviderNameLength;
+
+        // Index to the Options part of TracepointName, i.e. the part of the
+        // TracepointName after level and keyword, e.g. if TracepointName is
+        // "ProviderName_LnKnnnOptions", this will be 19.
+        uint8_t OptionsIndex;
+    };
+
+    struct EventItemInfo
+    {
+        // "FieldName" followed by 0 or more field attributes.
+        // Each attribute is ";AttribName=AttribValue".
+        // FieldName should not contain ';'.
+        // AttribName should not contain ';' or '='.
+        // AttribValue may contain ";;" which should be unescaped to ";".
+        _Field_z_ char const* Name;
+
+        // Raw field value bytes.
+        // May need byte-swap (check e.NeedByteSwap() or eventInfo.header.flags).
+        // For strings, does not include length prefix or nul-termination.
+        _Field_size_bytes_(ValueSize) void const* ValueData;
+
+        // Raw field value size (in bytes).
+        // This is nonzero for Value items and for ArrayBegin of array of simple values.
+        // This is zero for everything else, including ArrayBegin of array of complex items.
+        // For strings, does not include length prefix or nul-termination.
+        uint32_t ValueSize;
+
+        // Array element index.
+        // For non-array, this is 0.
+        // For ArrayBegin, this is 0.
+        // For ArrayEnd, this is ArrayCount.
         uint16_t ArrayIndex;
+
+        // Array element count. For non-array, this is 1.
         uint16_t ArrayCount;
-        uint8_t  RemainingFieldCount; // Number of NextProperty() calls before popping stack.
-        uint8_t  ArrayFlags; // Encoding & EncodingCountMask
-    };
 
-    struct FieldType
-    {
+        // Nonzero for simple items (fixed-size non-struct).
+        // Zero for complex items (variable-size or struct).
+        uint32_t ElementSize : 8;
+
+        // Field's underlying encoding. The encoding indicates how to determine the field's
+        // size and the semantic type to use when Format = Default.
         event_field_encoding Encoding : 8;
-        event_field_format   Format : 8;
-        unsigned Tag : 16;
+
+        // Field's semantic type. May be Default, in which case the semantic type should be
+        // determined based on the default format for the field's encoding.
+        // For StructBegin/StructEnd, this contains the struct field count.
+        event_field_format Format : 8;
+
+        // 0 if item is a non-array Value.
+        // event_field_encoding_carray_flag if item is a fixed-length ArrayBegin, ArrayEnd, or array Value.
+        // event_field_encoding_varray_flag if item is a variable-length ArrayBegin, ArrayEnd, or array Value.
+        event_field_encoding ArrayFlags : 8;
+
+        // True if event's byte order != host byte order.
+        bool NeedByteSwap;
+
+        // Field tag, or 0 if none.
+        uint16_t FieldTag;
     };
-
-private:
-
-    // Set up by StartEvent:
-    eventheader m_header;
-    uint64_t m_keyword;
-    uint8_t const* m_metaBuf;
-    uint8_t const* m_dataBuf;
-    uint8_t const* m_activityIdBuf;
-    char const* m_tracepointName; // Not nul-terminated.
-    uint8_t m_tracepointNameLength;
-    uint8_t m_providerNameLength; // Index into m_tracepointName
-    uint8_t m_optionsIndex; // Index into m_tracepointName
-    uint16_t m_metaEnd;
-    uint8_t m_activityIdSize;
-    bool m_needByteSwap;
-    uint16_t m_eventNameSize; // Name starts at m_metaBuf
-    uint32_t m_dataEnd;
-
-    // Values change during enumeration:
-    uint32_t m_dataPosRaw;
-    uint32_t m_moveNextRemaining;
-    StackEntry m_stackTop;
-    uint8_t m_stackIndex; // Number of items currently on stack.
-    EventEnumeratorState m_state;
-    SubState m_subState;
-    EventEnumeratorError m_lastError;
-
-    uint8_t m_elementSize; // 0 if item is variable-size or complex.
-    FieldType m_fieldType; // Note: fieldType.Encoding is cooked.
-    uint32_t m_dataPosCooked;
-    uint32_t m_itemSizeRaw;
-    uint32_t m_itemSizeCooked;
-
-    // Limit events to 8 levels of nested structures.
-    StackEntry m_stack[8];
-
-public:
-
-    static uint32_t const MoveNextLimitDefault = 4096;
-
-    /// <summary>
-    /// Initializes a new instance of EventEnumerator. Sets State to None.
-    /// </summary>
-    EventEnumerator() noexcept;
-
-    /// <summary>
-    /// Returns the current state.
-    /// </summary>
-    EventEnumeratorState
-    State() const noexcept;
-
-    /// <summary>
-    /// Gets status for the most recent call to StartEvent, MoveNext, or MoveNextSibling.
-    /// </summary>
-    EventEnumeratorError
-    LastError() const noexcept;
-
-    /// <summary>
-    /// Sets State to None.
-    /// </summary>
-    void
-    Clear() noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Starts decoding the specified EventHeader event: decodes the header and
-    /// positions the enumerator before the first item.
-    /// </para><para>
-    /// On success, changes the state to BeforeFirstItem and returns true.
-    /// On failure, changes the state to None (not Error) and returns false.
-    /// </para><para>
-    /// Note that the enumerator stores the pchTracepointName and pData pointers but
-    /// does not copy the referenced data, so the referenced data must remain valid
-    /// and unchanged while you are processing the data with this enumerator (i.e.
-    /// do not deallocate or overwrite the name or data until you call Clear, make
-    /// another call to StartEvent, or destroy this EventEnumerator instance).
-    /// </para>
-    /// </summary>
-    /// <param name="pchTracepointName">Set to tep_event->name, e.g. "MyProvider_L4K1".
-    /// Must follow the tracepoint name rules described in eventheader.h.</param>
-    /// <param name="cchTracepointName">Set to strlen(tep_event->name). Must be less
-    /// than EVENTHEADER_NAME_MAX.</param>
-    /// <param name="pData">Set to pointer to the start of the event data (the eventheader_flags
-    /// field of the event header), usually something like
-    /// tep_record->data + tep_event->format.fields[0].offset.</param>
-    /// <param name="cbData">Set to size of the data, usually something like
-    /// tep_record->size - tep_event->format.fields[0].offset.</param>
-    /// <param name="moveNextLimit">Set to the maximum number of MoveNext calls to allow when
-    /// processing this event (to guard against DoS attacks from a maliciously-crafted
-    /// event).</param>
-    /// <returns>Returns false for failure. Check LastError for details.</returns>
-    bool
-    StartEvent(
-        _In_reads_bytes_(cchTracepointName) char const* pchTracepointName, // e.g. "MyProvider_L4K1"
-        size_t cchTracepointName, // e.g. strlen(pchTracepointName)
-        _In_reads_bytes_(cbData) void const* pData, // points at the eventheader_flags field
-        size_t cbData, // size in bytes of the pData buffer
-        uint32_t moveNextLimit = MoveNextLimitDefault) noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Positions the enumerator before the first item.
-    /// </para><para>
-    /// PRECONDITION: Can be called when State != None, i.e. at any time after a
-    /// successful call to StartEvent, until a call to Clear.
-    /// </para>
-    /// </summary>
-    void
-    Reset(uint32_t moveNextLimit = MoveNextLimitDefault) noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Moves the enumerator to the next item in the current event, or to the end
-    /// of the event if no more items. Returns true if moved to a valid item,
-    /// false if no more items or decoding error.
-    /// </para><para>
-    /// PRECONDITION: Can be called when State >= BeforeFirstItem, i.e. after a
-    /// successful call to StartEvent, until MoveNext returns false.
-    /// </para><para>
-    /// Typically called in a loop until it returns false, e.g.:
-    /// </para><code>
-    /// if (!e.StartEvent(...)) return e.LastError();
-    /// while (e.MoveNext())
-    /// {
-    ///     EventItemInfo item = e.GetItemInfo();
-    ///     switch (e.State())
-    ///     {
-    ///     case EventEnumeratorState_Value:
-    ///         DoValue(item);
-    ///         break;
-    ///     case EventEnumeratorState_StructBegin:
-    ///         DoStructBegin(item);
-    ///         break;
-    ///     case EventEnumeratorState_StructEnd:
-    ///         DoStructEnd(item);
-    ///         break;
-    ///     case EventEnumeratorState_ArrayBegin:
-    ///         DoArrayBegin(item);
-    ///         break;
-    ///     case EventEnumeratorState_ArrayEnd:
-    ///         DoArrayEnd(item);
-    ///         break;
-    ///     }
-    /// }
-    /// return e.LastError();
-    /// </code>
-    /// </summary>
-    /// <returns>
-    /// Returns true if moved to a valid item.
-    /// Returns false and sets state to AfterLastItem if no more items.
-    /// Returns false and sets state to Error for decoding error.
-    /// Check LastError for details.
-    /// </returns>
-    bool
-    MoveNext() noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Moves the enumerator to the next sibling of the current item, or to the end
-    /// of the event if no more items. Returns true if moved to a valid item, false
-    /// if no more items or decoding error.
-    /// </para><para>
-    /// PRECONDITION: Can be called when State >= BeforeFirstItem, i.e. after a
-    /// successful call to StartEvent, until MoveNext returns false.
-    /// </para><list type="bullet"><item>
-    /// If the current item is ArrayBegin or StructBegin, this efficiently moves
-    /// enumeration to AFTER the corresponding ArrayEnd or StructEnd.
-    /// </item><item>
-    /// Otherwise, this is the same as MoveNext.
-    /// </item></list><para>
-    /// Typical use for this method is to efficiently skip past an array of fixed-size
-    /// items (i.e. an array where ElementSize is nonzero) when you process all of the
-    /// array items within the ArrayBegin state.
-    /// </para><code>
-    /// if (!e.StartEvent(...)) return e.LastError(); // Error.
-    /// if (!e.MoveNext()) return e.LastError(); // AfterLastItem or Error.
-    /// while (true)
-    /// {
-    ///     EventItemInfo item = e.GetItemInfo();
-    ///     switch (e.State())
-    ///     {
-    ///     case EventEnumeratorState_Value:
-    ///         DoValue(item);
-    ///         break;
-    ///     case EventEnumeratorState_StructBegin:
-    ///         DoStructBegin(item);
-    ///         break;
-    ///     case EventEnumeratorState_StructEnd:
-    ///         DoStructEnd(item);
-    ///         break;
-    ///     case EventEnumeratorState_ArrayBegin:
-    ///         if (e.ElementSize == 0)
-    ///         {
-    ///             DoComplexArrayBegin(item);
-    ///         }
-    ///         else
-    ///         {
-    ///             // Process the entire array directly without using the enumerator.
-    ///             DoSimpleArrayBegin(item);
-    ///             for (unsigned i = 0; i != item.ArrayCount; i++)
-    ///             {
-    ///                 DoArrayElement(item, i);
-    ///             }
-    ///             DoSimpleArrayEnd(item);
-    /// 
-    ///             // Skip the entire array at once.
-    ///             if (!e.MoveNextSibling()) // Instead of MoveNext().
-    ///             {
-    ///                 return e.LastError(); // AfterLastItem or Error.
-    ///             }
-    ///             continue; // Skip the MoveNext().
-    ///         }
-    ///         break;
-    ///     case EventEnumeratorState_ArrayEnd:
-    ///         DoComplexArrayEnd(item);
-    ///         break;
-    ///     }
-    ///
-    ///     if (!e.MoveNext())
-    ///     {
-    ///         return e.LastError(); // AfterLastItem or Error.
-    ///     }
-    /// }
-    /// </code>
-    /// </summary>
-    /// <returns>
-    /// Returns true if moved to a valid item.
-    /// Returns false and sets state to AfterLastItem if no more items.
-    /// Returns false and sets state to Error for decoding error.
-    /// Check LastError for details.
-    /// </returns>
-    bool
-    MoveNextSibling() noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Advanced scenarios. This method is for extracting type information from an
-    /// event without looking at value information. Moves the enumerator to the next
-    /// field declaration (not the next field value). Returns true if moved to a valid
-    /// item, false if no more items or decoding error.
-    /// </para><para>
-    /// PRECONDITION: Can be called after a successful call to StartEvent, until
-    /// MoveNextMetadata returns false.
-    /// </para><para>
-    /// Note that metadata enumeration gives a flat view of arrays and structures.
-    /// There are only Value items, no BeginArray, EndArray, BeginStruct, EndStruct.
-    /// A struct shows up as a value with Encoding = Struct (Format holds field count).
-    /// An array shows up as a value with ArrayFlags != 0, and ArrayCount is either zero
-    /// (indicating a runtime-variable array length) or nonzero (indicating a compile-time
-    /// constant array length). An array of struct is a field with Encoding = Struct and
-    /// ArrayFlags != 0. ValueBytes will always be empty. ArrayIndex and ElementSize
-    /// will always be zero.
-    /// </para><para>
-    /// Note that when enumerating metadata for a structure, the enumeration may end before
-    /// the expected number of fields are seen. This is a supported scenario and is not an
-    /// error in the event. A large field count just means "this structure contains all the
-    /// remaining fields in the event".
-    /// </para><para>
-    /// Typically called in a loop until it returns false.
-    /// </para><code>
-    /// if (!e.StartEvent(...)) return e.LastError();
-    /// while (e.MoveNextMetadata())
-    /// {
-    ///     DoFieldDeclaration(e.GetItemInfo());
-    /// }
-    /// return e.LastError();
-    /// </code>
-    /// </summary>
-    /// <returns>
-    /// Returns true if moved to a valid item.
-    /// Returns false and sets state to AfterLastItem if no more items.
-    /// Returns false and sets state to Error for decoding error.
-    /// Check LastError for details.
-    /// </returns>
-    bool
-    MoveNextMetadata() noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Gets information that applies to the current event, e.g. the event name,
-    /// provider name, options, level, keyword, etc.
-    /// </para><para>
-    /// PRECONDITION: Can be called when State != None, i.e. at any time after a
-    /// successful call to StartEvent, until a call to Clear.
-    /// </para>
-    /// </summary>
-    EventInfo
-    GetEventInfo() const noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Gets information that applies to the current item, e.g. the item's name,
-    /// the item's type (integer, string, float, etc.), data pointer, data size.
-    /// The current item changes each time MoveNext() is called.
-    /// </para><para>
-    /// PRECONDITION: Can be called when State > BeforeFirstItem, i.e. after MoveNext
-    /// returns true.
-    /// </para>
-    /// </summary>
-    EventItemInfo
-    GetItemInfo() const noexcept;
-
-    /// <summary>
-    /// <para>
-    /// Gets the remaining event payload, i.e. the event data that has not yet
-    /// been decoded. The data position can change each time MoveNext is called.
-    /// </para><para>
-    /// PRECONDITION: Can be called when State != None, i.e. at any time after a
-    /// successful call to StartEvent, until a call to Clear.
-    /// </para><para>
-    /// This can be useful after enumeration has completed to to determine
-    /// whether the event contains any trailing data (data not described by the
-    /// decoding information). Up to 3 bytes of trailing data is normal (padding
-    /// between events), but 4 or more bytes of trailing data might indicate some
-    /// kind of encoding problem or data corruption.
-    /// </para>
-    /// </summary>
-    EventDataPosition
-    GetRawDataPosition() const noexcept;
-
-private:
-
-    void
-    ResetImpl(uint32_t moveNextLimit) noexcept;
-
-    bool
-    SkipStructMetadata() noexcept;
-
-    bool
-    NextProperty() noexcept;
-
-    /// <summary>
-    /// Requires m_metaEnd >= m_stackTop.NameOffset.
-    /// Reads name, encoding, format, tag starting at m_stackTop.NameOffset.
-    /// Updates m_stackTop.NameSize, m_stackTop.NextOffset.
-    /// On failure, returns Encoding = None.
-    /// </summary>
-    FieldType
-    ReadFieldNameAndType() noexcept;
-
-    /// <summary>
-    /// Requires m_metaEnd > typeOffset.
-    /// Reads encoding, format, tag starting at m_stackTop.NameOffset.
-    /// Updates m_stackTop.NextOffset.
-    /// On failure, returns Encoding = None.
-    /// </summary>
-    FieldType
-    ReadFieldType(uint16_t typeOffset) noexcept;
-
-    bool
-    StartArray() noexcept;
-
-    void
-    StartStruct() noexcept;
-
-    bool
-    StartValue() noexcept;
-
-    void
-    StartValueSimple() noexcept;
-
-    template<class CH>
-    void
-    StartValueStringNul() noexcept;
-
-    void
-    StartValueStringLength16(uint8_t charSizeShift) noexcept;
-
-    void
-    SetState(EventEnumeratorState newState, SubState newSubState) noexcept;
-
-    void
-    SetEndState(EventEnumeratorState newState, SubState newSubState) noexcept;
-
-    bool
-    SetNoneState(EventEnumeratorError error) noexcept;
-
-    bool
-    SetErrorState(EventEnumeratorError error) noexcept;
-};
-
-/// <summary>
-/// Enumeration states.
-/// </summary>
-enum EventEnumeratorState : uint8_t
-{
-    /// <summary>
-    /// After construction, a call to Clear, or a failed StartEvent.
-    /// </summary>
-    EventEnumeratorState_None,
-
-    /// <summary>
-    /// After an error has been returned by MoveNext.
-    /// </summary>
-    EventEnumeratorState_Error,
-
-    /// <summary>
-    /// Positioned after the last item in the event.
-    /// </summary>
-    EventEnumeratorState_AfterLastItem,
-
-    // MoveNext() is an invalid operation for all states above this line.
-    // MoveNext() is a valid operation for all states below this line.
-
-    /// <summary>
-    /// Positioned before the first item in the event.
-    /// </summary>
-    EventEnumeratorState_BeforeFirstItem,
-
-    // GetItemInfo() is an invalid operation for all states above this line.
-    // GetItemInfo() is a valid operation for all states below this line.
-
-    /// <summary>
-    /// Positioned at an item with data (a field or an array element).
-    /// </summary>
-    EventEnumeratorState_Value,
-
-    /// <summary>
-    /// Positioned before the first item in an array.
-    /// </summary>
-    EventEnumeratorState_ArrayBegin,
-
-    /// <summary>
-    /// Positioned after the last item in an array.
-    /// </summary>
-    EventEnumeratorState_ArrayEnd,
-
-    /// <summary>
-    /// Positioned before the first item in a struct.
-    /// </summary>
-    EventEnumeratorState_StructBegin,
-
-    /// <summary>
-    /// Positioned after the last item in a struct.
-    /// </summary>
-    EventEnumeratorState_StructEnd,
-};
-
-/// <summary>
-/// Values for the LastError property.
-/// </summary>
-enum EventEnumeratorError : uint8_t
-{
-    /// <summary>
-    /// No error.
-    /// </summary>
-    EventEnumeratorError_Success = 0,
-
-    /// <summary>
-    /// Event is smaller than 8 bytes or larger than 2GB,
-    /// or TracepointName is longer than 255 characters.
-    /// </summary>
-    EventEnumeratorError_InvalidParameter = EINVAL,
-
-    /// <summary>
-    /// Event does not follow the EventHeader naming/layout rules,
-    /// is big-endian, has unrecognized flags, or unrecognized types.
-    /// </summary>
-    EventEnumeratorError_NotSupported = ENOTSUP,
-
-    /// <summary>
-    /// Resource usage limit (moveNextLimit) reached.
-    /// </summary>
-    EventEnumeratorError_ImplementationLimit = E2BIG,
-
-    /// <summary>
-    /// Event has an out-of-range value.
-    /// </summary>
-    EventEnumeratorError_InvalidData = EBADMSG,
-
-    /// <summary>
-    /// Event has more than 8 levels of nested structs.
-    /// </summary>
-    EventEnumeratorError_StackOverflow = EOVERFLOW,
-
-    /// <summary>
-    /// Method call invalid for current State().
-    /// </summary>
-    EventEnumeratorError_InvalidState = EPERM,
-};
-
-struct EventDataPosition
-{
-    _Field_size_bytes_(Size) void const* Data;
-    uint32_t Size;
-};
-
-struct EventInfo
-{
-    // "EventName" followed by 0 or more event attributes.
-    // Each attribute is ";AttribName=AttribValue".
-    // EventName should not contain ';'.
-    // AttribName should not contain ';' or '='.
-    // AttribValue may contain ";;" which should be unescaped to ";".
-    _Field_z_ char const* Name;
-
-    // TracepointName, e.g. "ProviderName_LnKnnnOptions".
-    // May not be nul-terminated. Length is TracepointNameLength.
-    _Field_size_bytes_(TracepointNameLength) char const* TracepointName;
-
-    // 128-bit big-endian activity id, or NULL if none.
-    _Field_size_bytes_opt_(16) uint8_t const* ActivityId;
-
-    // 128-bit big-endian related activity id, or NULL if none.
-    _Field_size_bytes_opt_(16) uint8_t const* RelatedActivityId;
-
-    // flags, version, id, tag, opcode, level.
-    eventheader Header;
-
-    // Event category bits.
-    uint64_t Keyword;
-
-    // Length of TracepointName.
-    uint8_t TracepointNameLength;
-
-    // Length of the ProviderName part of TracepointName, e.g. if
-    // TracepointName is "ProviderName_LnKnnnOptions", this will be 12
-    // since strlen("ProviderName") = 12.
-    uint8_t ProviderNameLength;
-
-    // Index to the Options part of TracepointName, i.e. the part of the
-    // TracepointName after level and keyword, e.g. if TracepointName is
-    // "ProviderName_LnKnnnOptions", this will be 19.
-    uint8_t OptionsIndex;
-};
-
-struct EventItemInfo
-{
-    // "FieldName" followed by 0 or more field attributes.
-    // Each attribute is ";AttribName=AttribValue".
-    // FieldName should not contain ';'.
-    // AttribName should not contain ';' or '='.
-    // AttribValue may contain ";;" which should be unescaped to ";".
-    _Field_z_ char const* Name;
-
-    // Raw field value bytes.
-    // May need byte-swap (check e.NeedByteSwap() or eventInfo.header.flags).
-    // For strings, does not include length prefix or nul-termination.
-    _Field_size_bytes_(ValueSize) void const* ValueData;
-
-    // Raw field value size (in bytes).
-    // This is nonzero for Value items and for ArrayBegin of array of simple values.
-    // This is zero for everything else, including ArrayBegin of array of complex items.
-    // For strings, does not include length prefix or nul-termination.
-    uint32_t ValueSize;
-
-    // Array element index.
-    // For non-array, this is 0.
-    // For ArrayBegin, this is 0.
-    // For ArrayEnd, this is ArrayCount.
-    uint16_t ArrayIndex;
-
-    // Array element count. For non-array, this is 1.
-    uint16_t ArrayCount;
-
-    // Nonzero for simple items (fixed-size non-struct).
-    // Zero for complex items (variable-size or struct).
-    uint32_t ElementSize : 8;
-
-    // Field's underlying encoding. The encoding indicates how to determine the field's
-    // size and the semantic type to use when Format = Default.
-    event_field_encoding Encoding : 8;
-
-    // Field's semantic type. May be Default, in which case the semantic type should be
-    // determined based on the default format for the field's encoding.
-    // For StructBegin/StructEnd, this contains the struct field count.
-    event_field_format Format : 8;
-
-    // 0 if item is a non-array Value.
-    // event_field_encoding_carray_flag if item is a fixed-length ArrayBegin, ArrayEnd, or array Value.
-    // event_field_encoding_varray_flag if item is a variable-length ArrayBegin, ArrayEnd, or array Value.
-    event_field_encoding ArrayFlags : 8;
-
-    // True if event's byte order != host byte order.
-    bool NeedByteSwap;
-
-    // Field tag, or 0 if none.
-    uint16_t FieldTag;
-};
+}
+// namespace eventheader_decode
 
 #endif // _included_EventEnumerator_h

--- a/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
+++ b/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
@@ -8,209 +8,214 @@
 #include "EventEnumerator.h"
 #include <string>
 
-// Forward declarations from <tracepoint/PerfDataFile.h>
-struct PerfSampleEventInfo;
-
-// Forward declarations from <tracepoint/PerfEventMetadata.h>
-class PerfFieldMetadata;
-
-// Forward declarations from this file.
-enum EventFormatterJsonFlags : unsigned;
-enum EventFormatterMetaFlags : unsigned;
-
-/*
-Helper for converting event fields to strings.
-*/
-class EventFormatter
+namespace tracepoint_decode
 {
-public:
+    // Forward declarations from libtracepoint-decode
+    struct PerfSampleEventInfo;
+    class PerfFieldMetadata;
+}
 
-    /*
-    Formats the specified sample as a UTF-8 JSON string and appends the
-    result to dest.
-
-    If the Name flag is not specified, the appended string is a valid JSON object.
-    If the Name flag is specified, the appended string is a valid JSON member,
-    i.e. it is a "FieldName": prefix followed by a valid JSON object.
-
-    If the Space flag is specified, the appended string will begin with a space
-    and will have spaces between elements, e.g. after ',' and ':'.
-
-    Returns 0 for success, errno for error. May throw bad_alloc.
-    */
-    int
-    AppendSampleAsJson(
-        std::string& dest,
-        PerfSampleEventInfo const& sampleEventInfo,
-        bool fileBigEndian,
-        EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0),
-        EventFormatterMetaFlags metaFlags = static_cast<EventFormatterMetaFlags>(0xffff),
-        uint32_t moveNextLimit = 4096);
-
-    /*
-    Formats the specified sample field as a UTF-8 JSON string and appends the
-    result to dest.
-
-    If the Name flag is not specified, the appended string is a valid JSON value.
-    If the Name flag is specified, the appended string is a valid JSON member,
-    i.e. it is a "FieldName": prefix followed by a valid JSON value.
-
-    If the Space flag is specified, the appended string will begin with a space
-    and will have spaces between elements, e.g. after ',' and ':'.
-
-    Returns 0 for success, errno for error. May throw bad_alloc.
-    */
-    int
-    AppendSampleFieldAsJson(
-        std::string& dest,
-        _In_reads_bytes_(fieldRawDataSize) void const* fieldRawData,
-        size_t fieldRawDataSize,
-        PerfFieldMetadata const& fieldMetadata,
-        bool fileBigEndian,
-        EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0));
-
-    /*
-    Formats the enumerator's event as a UTF-8 JSON string and appends the
-    result to dest. Moves the enumerator to the end of the event.
-    
-    If the Name flag is not specified, the appended string is a valid JSON object.
-    If the Name flag is specified, the appended string is a valid JSON member,
-    i.e. it is a "FieldName": prefix followed by a valid JSON object.
-
-    If the Space flag is specified, the appended string will begin with a space
-    and will have spaces between elements, e.g. after ',' and ':'.
-
-    Returns 0 for success, errno for error. May throw bad_alloc.
-
-    Requires: enumerator.State is BeforeFirstItem.
-    */
-    int
-    AppendEventAsJsonAndMoveToEnd(
-        std::string& dest,
-        EventEnumerator& enumerator,
-        EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0),
-        EventFormatterMetaFlags metaFlags = static_cast<EventFormatterMetaFlags>(0xffff));
-
-    /*
-    Formats the item at the enumerator's current position (a value, array
-    begin, or structure begin) as UTF-8 JSON string and appends the result to
-    dest. Moves the enumerator to the next item as if by MoveNextSibling.
-    
-    Returns 0 for success, errno for error. May throw bad_alloc.
-
-    Requires: enumerator.State is Value, ArrayBegin, or StructBegin.
-
-    Booleans, decimal integers, and finite floating-point data values will be
-    unquoted. Other simple data values (including hexadecimal integers, infinities
-    and NaNs) will be quoted. Complex items (structures and arrays) will be
-    converted to JSON objects and arrays.
-
-    If the Name flag is not specified, the appended string is a valid JSON value.
-    If the Name flag is specified, the appended string is a valid JSON member,
-    i.e. it is a "FieldName": prefix followed by a valid JSON value.
-
-    If the Space flag is specified, the appended string will begin with a space
-    and will have spaces between elements, e.g. after ',' and ':'.
-    */
-    int
-    AppendItemAsJsonAndMoveNextSibling(
-        std::string& dest,
-        EventEnumerator& enumerator,
-        EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0));
-
-    /*
-    Formats the event field value at the enumerator's current position as a
-    UTF-8 string and appends the result to dest.
-    
-    Returns 0 for success, errno for error. May throw bad_alloc.
-
-    Requires: enumerator.State is Value.
-    */
-    int
-    AppendValue(
-        std::string& dest,
-        EventEnumerator const& enumerator);
-
-    /*
-    Formats the event field value as a UTF-8 string and appends the
-    result to dest.
-    
-    Returns 0 for success, errno for error. May throw bad_alloc.
-    
-    Requires: valueItem is a Value, not an ArrayBegin, StructEnd, etc.
-    */
-    int
-    AppendValue(
-        std::string& dest,
-        EventItemInfo const& valueItemInfo);
-
-    /*
-    Formats the specified event field value as a UTF-8 string and appends the
-    result to dest.
-    
-    Returns 0 for success, errno for error. May throw bad_alloc.
-    */
-    int
-    AppendValue(
-        std::string& dest,
-        _In_reads_bytes_(valueSize) void const* valueData,
-        uint32_t valueSize,
-        event_field_encoding encoding,
-        event_field_format format,
-        bool needsByteSwap);
-
-    /*
-    Formats the specified big-endian UUID value as a UTF-8 string and appends
-    the result to dest. UUID is formatted as 36 chars with dashes, e.g.
-    "00000000-0000-0000-0000-000000000000".
-
-    May throw bad_alloc.
-    */
-    void
-    AppendUuid(
-        std::string& dest,
-        _In_reads_bytes_(16) uint8_t const* uuid);
-};
-
-/*
-Flags for use when formatting an item as a JSON string with
-AppendItemAsJsonAndMoveNextSibling.
-*/
-enum EventFormatterJsonFlags : unsigned
+namespace eventheader_decode
 {
-    EventFormatterJsonFlags_None = 0,
-    EventFormatterJsonFlags_Name = 0x1,  // Include a "Name": prefix for root item.
-    EventFormatterJsonFlags_Space = 0x2, // Include a space between values.
-    EventFormatterJsonFlags_FieldTag = 0x4, // Append ";tag=0xNNNN" to name of fields if tag != 0.
-};
+    // Forward declarations from this file.
+    enum EventFormatterJsonFlags : unsigned;
+    enum EventFormatterMetaFlags : unsigned;
 
-/*
-Flags controlling the metadata to be included in the "meta" suffix of a JSON
-event string.
-*/
-enum EventFormatterMetaFlags : unsigned
-{
-    EventFormatterMetaFlags_None = 0,           // disable the "meta" suffix.
-    EventFormatterMetaFlags_n = 0x1,            // "n":"provider:event" before the user fields (not in the suffix).
-    EventFormatterMetaFlags_time = 0x2,         // timestamp "seconds.nanoseconds" (only for sample events).
-    EventFormatterMetaFlags_cpu = 0x4,          // cpu index (only for sample events).
-    EventFormatterMetaFlags_pid = 0x8,          // process id (only for sample events).
-    EventFormatterMetaFlags_tid = 0x10,         // thread id (only for sample events).
-    EventFormatterMetaFlags_id = 0x20,          // eventheader id (decimal integer, omitted if 0).
-    EventFormatterMetaFlags_version = 0x40,     // eventheader version (decimal integer, omitted if 0).
-    EventFormatterMetaFlags_level = 0x80,       // eventheader level (decimal integer, omitted if 0).
-    EventFormatterMetaFlags_keyword = 0x100,    // eventheader keyword (hexadecimal string, omitted if 0).
-    EventFormatterMetaFlags_opcode = 0x200,     // eventheader opcode (decimal integer, omitted if 0).
-    EventFormatterMetaFlags_tag = 0x400,        // eventheader tag (hexadecimal string, omitted if 0).
-    EventFormatterMetaFlags_activity = 0x800,   // eventheader activity ID (UUID string, omitted if 0).
-    EventFormatterMetaFlags_relatedActivity = 0x1000,// eventheader related activity ID (UUID string, omitted if not set).
-    EventFormatterMetaFlags_provider = 0x10000, // provider name or system name (string).
-    EventFormatterMetaFlags_event = 0x20000,    // event name or tracepoint name (string).
-    EventFormatterMetaFlags_options = 0x40000,  // eventheader provider options (string, omitted if none).
-    EventFormatterMetaFlags_flags = 0x80000,    // eventheader flags (hexadecimal string).
-    EventFormatterMetaFlags_common = 0x100000,  // Include the common_* fields before the user fields (only for sample events).
-    EventFormatterMetaFlags_Default = 0xffff,   // Include n..relatedActivity.
-    EventFormatterMetaFlags_All = ~0u
-};
+    /*
+    Helper for converting event fields to strings.
+    */
+    class EventFormatter
+    {
+    public:
+
+        /*
+        Formats the specified sample as a UTF-8 JSON string and appends the
+        result to dest.
+
+        If the Name flag is not specified, the appended string is a valid JSON object.
+        If the Name flag is specified, the appended string is a valid JSON member,
+        i.e. it is a "FieldName": prefix followed by a valid JSON object.
+
+        If the Space flag is specified, the appended string will begin with a space
+        and will have spaces between elements, e.g. after ',' and ':'.
+
+        Returns 0 for success, errno for error. May throw bad_alloc.
+        */
+        int
+        AppendSampleAsJson(
+            std::string& dest,
+            tracepoint_decode::PerfSampleEventInfo const& sampleEventInfo,
+            bool fileBigEndian,
+            EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0),
+            EventFormatterMetaFlags metaFlags = static_cast<EventFormatterMetaFlags>(0xffff),
+            uint32_t moveNextLimit = 4096);
+
+        /*
+        Formats the specified sample field as a UTF-8 JSON string and appends the
+        result to dest.
+
+        If the Name flag is not specified, the appended string is a valid JSON value.
+        If the Name flag is specified, the appended string is a valid JSON member,
+        i.e. it is a "FieldName": prefix followed by a valid JSON value.
+
+        If the Space flag is specified, the appended string will begin with a space
+        and will have spaces between elements, e.g. after ',' and ':'.
+
+        Returns 0 for success, errno for error. May throw bad_alloc.
+        */
+        int
+        AppendSampleFieldAsJson(
+            std::string& dest,
+            _In_reads_bytes_(fieldRawDataSize) void const* fieldRawData,
+            size_t fieldRawDataSize,
+            tracepoint_decode::PerfFieldMetadata const& fieldMetadata,
+            bool fileBigEndian,
+            EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0));
+
+        /*
+        Formats the enumerator's event as a UTF-8 JSON string and appends the
+        result to dest. Moves the enumerator to the end of the event.
+    
+        If the Name flag is not specified, the appended string is a valid JSON object.
+        If the Name flag is specified, the appended string is a valid JSON member,
+        i.e. it is a "FieldName": prefix followed by a valid JSON object.
+
+        If the Space flag is specified, the appended string will begin with a space
+        and will have spaces between elements, e.g. after ',' and ':'.
+
+        Returns 0 for success, errno for error. May throw bad_alloc.
+
+        Requires: enumerator.State is BeforeFirstItem.
+        */
+        int
+        AppendEventAsJsonAndMoveToEnd(
+            std::string& dest,
+            EventEnumerator& enumerator,
+            EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0),
+            EventFormatterMetaFlags metaFlags = static_cast<EventFormatterMetaFlags>(0xffff));
+
+        /*
+        Formats the item at the enumerator's current position (a value, array
+        begin, or structure begin) as UTF-8 JSON string and appends the result to
+        dest. Moves the enumerator to the next item as if by MoveNextSibling.
+    
+        Returns 0 for success, errno for error. May throw bad_alloc.
+
+        Requires: enumerator.State is Value, ArrayBegin, or StructBegin.
+
+        Booleans, decimal integers, and finite floating-point data values will be
+        unquoted. Other simple data values (including hexadecimal integers, infinities
+        and NaNs) will be quoted. Complex items (structures and arrays) will be
+        converted to JSON objects and arrays.
+
+        If the Name flag is not specified, the appended string is a valid JSON value.
+        If the Name flag is specified, the appended string is a valid JSON member,
+        i.e. it is a "FieldName": prefix followed by a valid JSON value.
+
+        If the Space flag is specified, the appended string will begin with a space
+        and will have spaces between elements, e.g. after ',' and ':'.
+        */
+        int
+        AppendItemAsJsonAndMoveNextSibling(
+            std::string& dest,
+            EventEnumerator& enumerator,
+            EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0));
+
+        /*
+        Formats the event field value at the enumerator's current position as a
+        UTF-8 string and appends the result to dest.
+    
+        Returns 0 for success, errno for error. May throw bad_alloc.
+
+        Requires: enumerator.State is Value.
+        */
+        int
+        AppendValue(
+            std::string& dest,
+            EventEnumerator const& enumerator);
+
+        /*
+        Formats the event field value as a UTF-8 string and appends the
+        result to dest.
+    
+        Returns 0 for success, errno for error. May throw bad_alloc.
+    
+        Requires: valueItem is a Value, not an ArrayBegin, StructEnd, etc.
+        */
+        int
+        AppendValue(
+            std::string& dest,
+            EventItemInfo const& valueItemInfo);
+
+        /*
+        Formats the specified event field value as a UTF-8 string and appends the
+        result to dest.
+    
+        Returns 0 for success, errno for error. May throw bad_alloc.
+        */
+        int
+        AppendValue(
+            std::string& dest,
+            _In_reads_bytes_(valueSize) void const* valueData,
+            uint32_t valueSize,
+            event_field_encoding encoding,
+            event_field_format format,
+            bool needsByteSwap);
+
+        /*
+        Formats the specified big-endian UUID value as a UTF-8 string and appends
+        the result to dest. UUID is formatted as 36 chars with dashes, e.g.
+        "00000000-0000-0000-0000-000000000000".
+
+        May throw bad_alloc.
+        */
+        void
+        AppendUuid(
+            std::string& dest,
+            _In_reads_bytes_(16) uint8_t const* uuid);
+    };
+
+    /*
+    Flags for use when formatting an item as a JSON string with
+    AppendItemAsJsonAndMoveNextSibling.
+    */
+    enum EventFormatterJsonFlags : unsigned
+    {
+        EventFormatterJsonFlags_None = 0,
+        EventFormatterJsonFlags_Name = 0x1,  // Include a "Name": prefix for root item.
+        EventFormatterJsonFlags_Space = 0x2, // Include a space between values.
+        EventFormatterJsonFlags_FieldTag = 0x4, // Append ";tag=0xNNNN" to name of fields if tag != 0.
+    };
+
+    /*
+    Flags controlling the metadata to be included in the "meta" suffix of a JSON
+    event string.
+    */
+    enum EventFormatterMetaFlags : unsigned
+    {
+        EventFormatterMetaFlags_None = 0,           // disable the "meta" suffix.
+        EventFormatterMetaFlags_n = 0x1,            // "n":"provider:event" before the user fields (not in the suffix).
+        EventFormatterMetaFlags_time = 0x2,         // timestamp "seconds.nanoseconds" (only for sample events).
+        EventFormatterMetaFlags_cpu = 0x4,          // cpu index (only for sample events).
+        EventFormatterMetaFlags_pid = 0x8,          // process id (only for sample events).
+        EventFormatterMetaFlags_tid = 0x10,         // thread id (only for sample events).
+        EventFormatterMetaFlags_id = 0x20,          // eventheader id (decimal integer, omitted if 0).
+        EventFormatterMetaFlags_version = 0x40,     // eventheader version (decimal integer, omitted if 0).
+        EventFormatterMetaFlags_level = 0x80,       // eventheader level (decimal integer, omitted if 0).
+        EventFormatterMetaFlags_keyword = 0x100,    // eventheader keyword (hexadecimal string, omitted if 0).
+        EventFormatterMetaFlags_opcode = 0x200,     // eventheader opcode (decimal integer, omitted if 0).
+        EventFormatterMetaFlags_tag = 0x400,        // eventheader tag (hexadecimal string, omitted if 0).
+        EventFormatterMetaFlags_activity = 0x800,   // eventheader activity ID (UUID string, omitted if 0).
+        EventFormatterMetaFlags_relatedActivity = 0x1000,// eventheader related activity ID (UUID string, omitted if not set).
+        EventFormatterMetaFlags_provider = 0x10000, // provider name or system name (string).
+        EventFormatterMetaFlags_event = 0x20000,    // event name or tracepoint name (string).
+        EventFormatterMetaFlags_options = 0x40000,  // eventheader provider options (string, omitted if none).
+        EventFormatterMetaFlags_flags = 0x80000,    // eventheader flags (hexadecimal string).
+        EventFormatterMetaFlags_common = 0x100000,  // Include the common_* fields before the user fields (only for sample events).
+        EventFormatterMetaFlags_Default = 0xffff,   // Include n..relatedActivity.
+        EventFormatterMetaFlags_All = ~0u
+    };
+}
+// namespace eventheader_decode
 
 #endif // _included_EventFormatter_h

--- a/libeventheader-decode-cpp/samples/decode-file.cpp
+++ b/libeventheader-decode-cpp/samples/decode-file.cpp
@@ -18,6 +18,8 @@
 #define le32toh(x) x
 #endif // _WIN32
 
+using namespace eventheader_decode;
+
 struct fcloseDelete
 {
     void operator()(FILE* file) const noexcept

--- a/libeventheader-decode-cpp/src/EventEnumerator.cpp
+++ b/libeventheader-decode-cpp/src/EventEnumerator.cpp
@@ -20,6 +20,8 @@
 
 #endif // _WIN32
 
+using namespace eventheader_decode;
+
 template<class UINTnn>
 static char const*
 LowercaseHexToInt(char const* pch, char const* pchEnd, UINTnn* pVal) noexcept

--- a/libeventheader-decode-cpp/src/EventFormatter.cpp
+++ b/libeventheader-decode-cpp/src/EventFormatter.cpp
@@ -49,6 +49,8 @@
 #endif
 
 using namespace std::string_view_literals;
+using namespace eventheader_decode;
+using namespace tracepoint_decode;
 
 static auto constexpr HostEndianFlag =
     EVENTHEADER_LITTLE_ENDIAN

--- a/libeventheader-decode-cpp/tools/decode-perf.cpp
+++ b/libeventheader-decode-cpp/tools/decode-perf.cpp
@@ -13,6 +13,9 @@
 #define strerror_r(errnum, buf, buflen) (strerror_s(buf, buflen, errnum), buf)
 #endif // _WIN32
 
+using namespace eventheader_decode;
+using namespace tracepoint_decode;
+
 static bool
 FlushEvents(std::multimap<uint64_t, std::string>& events, bool comma) noexcept
 {

--- a/libeventheader-tracepoint/samples/CMakeLists.txt
+++ b/libeventheader-tracepoint/samples/CMakeLists.txt
@@ -1,10 +1,9 @@
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 add_executable(dynamic-sample
     dynamic-sample.cpp)
 target_link_libraries(dynamic-sample
     PUBLIC eventheader-tracepoint tracepoint)
+target_compile_features(dynamic-sample
+    PRIVATE cxx_std_17)
 
 add_executable(eventheader-sample
     sample.cpp)
@@ -18,3 +17,5 @@ add_executable(eventheader-interceptor-sample
     tracepoint-file.cpp)
 target_link_libraries(eventheader-interceptor-sample
     PUBLIC eventheader-tracepoint)
+target_compile_features(eventheader-interceptor-sample
+    PRIVATE cxx_std_17)

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfByteReader.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfByteReader.h
@@ -18,118 +18,122 @@
 #define _In_reads_bytes_(cb)
 #endif
 
-// Loads values from the perf event data buffer, handling misaligned
-// and byte-swapped values.
-class PerfByteReader
+namespace tracepoint_decode
 {
-    bool m_bigEndian;
-
-public:
-
-    // Initializes a data reader that treats input as host-endian.
-    //
-    // Postcondition: this->ByteSwapNeeded() == false.
-    PerfByteReader() noexcept;
-
-    // If bigEndian is true, initializes a data reader that assumes input is
-    // big-endian. Otherwise, assumes input is little-endian.
-    //
-    // Postcondition: this->BigEndian() == bigEndian.
-    explicit
-    PerfByteReader(bool bigEndian) noexcept;
-
-    // Returns true if this reader is treating its input data as big-endian.
-    // Returns false if this reader is treating its input data as little-endian.
-    bool
-    BigEndian() const noexcept;
-
-    // Returns BigEndian() != HOST_IS_BIG_ENDIAN.
-    bool
-    ByteSwapNeeded() const noexcept;
-
-    // Returns *pSrc as uint8_t.
-    uint8_t
-    ReadAsU8(_In_reads_bytes_(1) void const* pSrc) const noexcept;
-
-    // Reads 2 bytes from pSrc, performs byteswap if appropriate,
-    // then returns the result as uint16_t.
-    uint16_t
-    ReadAsU16(_In_reads_bytes_(2) void const* pSrc) const noexcept;
-
-    // Reads 4 bytes from pSrc, performs byteswap if appropriate,
-    // then returns the result as uint32_t.
-    uint32_t
-    ReadAsU32(_In_reads_bytes_(4) void const* pSrc) const noexcept;
-
-    // Reads 8 bytes from pSrc, performs byteswap if appropriate,
-    // then returns the result as uint64_t.
-    uint64_t
-    ReadAsU64(_In_reads_bytes_(8) void const* pSrc) const noexcept;
-
-    // Requires: cbSrc is 1, 2, or 4.
-    // Reads cbSrc bytes from pSrc, performs byteswap if appropriate,
-    // then returns the result cast to uint32_t.
-    uint32_t
-    ReadAsDynU32(_In_reads_bytes_(cbSrc) void const* pSrc, uint8_t cbSrc) const noexcept;
-
-    // Requires: cbSrc is 1, 2, 4, or 8.
-    // Reads cbSrc bytes from pSrc, performs byteswap if appropriate,
-    // then returns the result cast to uint64_t.
-    uint64_t
-    ReadAsDynU64(_In_reads_bytes_(cbSrc) void const* pSrc, uint8_t cbSrc) const noexcept;
-
-    // Requires: sizeof(ValType) is 1, 2, 4, or 8.
-    // Reads sizeof(ValType) bytes from pSrc, performs byteswap if appropriate,
-    // then returns the result cast to ValType.
-    // ValType should be a trivial type, e.g. uint32_t, long, or double.
-    template<class ValType>
-    ValType
-    ReadAs(_In_reads_bytes_(sizeof(ValType)) void const* pSrc) const noexcept
+    // Loads values from the perf event data buffer, handling misaligned
+    // and byte-swapped values.
+    class PerfByteReader
     {
-        if constexpr (sizeof(ValType) == sizeof(uint8_t))
-        {
-            ValType v;
-            memcpy(&v, &pSrc, sizeof(v));
-            return v;
-        }
-        else if constexpr (sizeof(ValType) == sizeof(uint16_t))
-        {
-            auto const uintVal = ReadAsU16(pSrc);
-            ValType v;
-            memcpy(&v, &uintVal, sizeof(v));
-            return v;
-        }
-        else if constexpr (sizeof(ValType) == sizeof(uint32_t))
-        {
-            auto const uintVal = ReadAsU32(pSrc);
-            ValType v;
-            memcpy(&v, &uintVal, sizeof(v));
-            return v;
-        }
-        else if constexpr (sizeof(ValType) == sizeof(uint64_t))
-        {
-            auto const uintVal = ReadAsU64(pSrc);
-            ValType v;
-            memcpy(&v, &uintVal, sizeof(v));
-            return v;
-        }
-        else
-        {
-            static_assert(sizeof(ValType) == 0,
-                "ReadAs supports values of size 1, 2, 4, and 8.");
-        }
-    }
+        bool m_bigEndian;
 
-    // Requires: sizeof(ValType) is 1, 2, 4, or 8.
-    // Reads sizeof(ValType) bytes from pSrc, performs byteswap if appropriate,
-    // then returns the result cast to ValType.
-    // ValType should be a trivial type, e.g. uint32_t, long, or double.
-    template<class ValType>
-    ValType
-    Read(_In_ ValType const* pSrc) const noexcept
-    {
-        return ReadAs<ValType>(pSrc);
-    }
-};
+    public:
+
+        // Initializes a data reader that treats input as host-endian.
+        //
+        // Postcondition: this->ByteSwapNeeded() == false.
+        PerfByteReader() noexcept;
+
+        // If bigEndian is true, initializes a data reader that assumes input is
+        // big-endian. Otherwise, assumes input is little-endian.
+        //
+        // Postcondition: this->BigEndian() == bigEndian.
+        explicit
+        PerfByteReader(bool bigEndian) noexcept;
+
+        // Returns true if this reader is treating its input data as big-endian.
+        // Returns false if this reader is treating its input data as little-endian.
+        bool
+        BigEndian() const noexcept;
+
+        // Returns BigEndian() != HOST_IS_BIG_ENDIAN.
+        bool
+        ByteSwapNeeded() const noexcept;
+
+        // Returns *pSrc as uint8_t.
+        uint8_t
+        ReadAsU8(_In_reads_bytes_(1) void const* pSrc) const noexcept;
+
+        // Reads 2 bytes from pSrc, performs byteswap if appropriate,
+        // then returns the result as uint16_t.
+        uint16_t
+        ReadAsU16(_In_reads_bytes_(2) void const* pSrc) const noexcept;
+
+        // Reads 4 bytes from pSrc, performs byteswap if appropriate,
+        // then returns the result as uint32_t.
+        uint32_t
+        ReadAsU32(_In_reads_bytes_(4) void const* pSrc) const noexcept;
+
+        // Reads 8 bytes from pSrc, performs byteswap if appropriate,
+        // then returns the result as uint64_t.
+        uint64_t
+        ReadAsU64(_In_reads_bytes_(8) void const* pSrc) const noexcept;
+
+        // Requires: cbSrc is 1, 2, or 4.
+        // Reads cbSrc bytes from pSrc, performs byteswap if appropriate,
+        // then returns the result cast to uint32_t.
+        uint32_t
+        ReadAsDynU32(_In_reads_bytes_(cbSrc) void const* pSrc, uint8_t cbSrc) const noexcept;
+
+        // Requires: cbSrc is 1, 2, 4, or 8.
+        // Reads cbSrc bytes from pSrc, performs byteswap if appropriate,
+        // then returns the result cast to uint64_t.
+        uint64_t
+        ReadAsDynU64(_In_reads_bytes_(cbSrc) void const* pSrc, uint8_t cbSrc) const noexcept;
+
+        // Requires: sizeof(ValType) is 1, 2, 4, or 8.
+        // Reads sizeof(ValType) bytes from pSrc, performs byteswap if appropriate,
+        // then returns the result cast to ValType.
+        // ValType should be a trivial type, e.g. uint32_t, long, or double.
+        template<class ValType>
+        ValType
+        ReadAs(_In_reads_bytes_(sizeof(ValType)) void const* pSrc) const noexcept
+        {
+            if constexpr (sizeof(ValType) == sizeof(uint8_t))
+            {
+                ValType v;
+                memcpy(&v, &pSrc, sizeof(v));
+                return v;
+            }
+            else if constexpr (sizeof(ValType) == sizeof(uint16_t))
+            {
+                auto const uintVal = ReadAsU16(pSrc);
+                ValType v;
+                memcpy(&v, &uintVal, sizeof(v));
+                return v;
+            }
+            else if constexpr (sizeof(ValType) == sizeof(uint32_t))
+            {
+                auto const uintVal = ReadAsU32(pSrc);
+                ValType v;
+                memcpy(&v, &uintVal, sizeof(v));
+                return v;
+            }
+            else if constexpr (sizeof(ValType) == sizeof(uint64_t))
+            {
+                auto const uintVal = ReadAsU64(pSrc);
+                ValType v;
+                memcpy(&v, &uintVal, sizeof(v));
+                return v;
+            }
+            else
+            {
+                static_assert(sizeof(ValType) == 0,
+                    "ReadAs supports values of size 1, 2, 4, and 8.");
+            }
+        }
+
+        // Requires: sizeof(ValType) is 1, 2, 4, or 8.
+        // Reads sizeof(ValType) bytes from pSrc, performs byteswap if appropriate,
+        // then returns the result cast to ValType.
+        // ValType should be a trivial type, e.g. uint32_t, long, or double.
+        template<class ValType>
+        ValType
+        Read(_In_ ValType const* pSrc) const noexcept
+        {
+            return ReadAs<ValType>(pSrc);
+        }
+    };
+}
+// namespace tracepoint_decode
 
 #endif // _included_PerfByteReader_h

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfDataFile.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfDataFile.h
@@ -44,257 +44,261 @@
 #define _Success_(condition)
 #endif
 
-// Forward declarations from PerfEventInfo.h:
-struct PerfSampleEventInfo;
-struct PerfNonSampleEventInfo;
-
-// Forward declaration from PerfEventMetadata.h:
-class PerfEventMetadata;
-
 // Forward declarations from PerfEventAbi.h or linux/uapi/linux/perf_event.h:
 struct perf_event_attr;
 struct perf_event_header;
 
-// uint8 header index.
-// From: perf.data-file-format.txt, perf/util/header.h.
-enum PerfHeaderIndex : uint8_t {
-    PERF_HEADER_RESERVED = 0,       // always cleared
-    PERF_HEADER_FIRST_FEATURE = 1,
-    PERF_HEADER_TRACING_DATA = 1,
-    PERF_HEADER_BUILD_ID,
-    PERF_HEADER_HOSTNAME,
-    PERF_HEADER_OSRELEASE,
-    PERF_HEADER_VERSION,
-    PERF_HEADER_ARCH,
-    PERF_HEADER_NRCPUS,
-    PERF_HEADER_CPUDESC,
-    PERF_HEADER_CPUID,
-    PERF_HEADER_TOTAL_MEM,
-    PERF_HEADER_CMDLINE,
-    PERF_HEADER_EVENT_DESC,
-    PERF_HEADER_CPU_TOPOLOGY,
-    PERF_HEADER_NUMA_TOPOLOGY,
-    PERF_HEADER_BRANCH_STACK,
-    PERF_HEADER_PMU_MAPPINGS,
-    PERF_HEADER_GROUP_DESC,
-    PERF_HEADER_AUXTRACE,
-    PERF_HEADER_STAT,
-    PERF_HEADER_CACHE,
-    PERF_HEADER_SAMPLE_TIME,
-    PERF_HEADER_MEM_TOPOLOGY,
-    PERF_HEADER_CLOCKID,
-    PERF_HEADER_DIR_FORMAT,
-    PERF_HEADER_BPF_PROG_INFO,
-    PERF_HEADER_BPF_BTF,
-    PERF_HEADER_COMPRESSED,
-    PERF_HEADER_CPU_PMU_CAPS,
-    PERF_HEADER_CLOCK_DATA,
-    PERF_HEADER_HYBRID_TOPOLOGY,
-    PERF_HEADER_PMU_CAPS,
-    PERF_HEADER_LAST_FEATURE,
-};
-
-struct PerfEventDesc
+namespace tracepoint_decode
 {
-    perf_event_attr const* attr;    // NULL for unknown id.
-    _Field_z_ char const* name;     // "" if no name available.
-};
+    // Forward declarations from PerfEventInfo.h:
+    struct PerfSampleEventInfo;
+    struct PerfNonSampleEventInfo;
 
-class PerfDataFile
-{
-    struct perf_file_section;
-    struct perf_pipe_header;
-    struct perf_file_header;
+    // Forward declaration from PerfEventMetadata.h:
+    class PerfEventMetadata;
 
-    uint64_t m_filePos;
-    uint64_t m_fileLen;
-    uint64_t m_dataBeginFilePos;
-    uint64_t m_dataEndFilePos;
-    FILE* m_file;
-    std::vector<uint8_t> m_eventData;
-    std::vector<char> m_headers[32]; // Stored file-endian.
-    std::vector<std::unique_ptr<perf_event_attr>> m_attrsList; // Stored host-endian.
-    std::map<uint64_t, PerfEventDesc> m_eventDescById; // Points into m_attrsList and/or m_headers.
-    PerfByteReader m_byteReader;
-    int8_t m_sampleIdOffset; // -1 = unset, -2 = no id.
-    int8_t m_nonSampleIdOffset; // -1 = unset, -2 = no id.
-    int8_t m_commonTypeOffset; // -1 = unset, -2 = not available.
-    uint8_t m_commonTypeSize;
-    bool m_parsedHeaderEventDesc;
+    // uint8 header index.
+    // From: perf.data-file-format.txt, perf/util/header.h.
+    enum PerfHeaderIndex : uint8_t {
+        PERF_HEADER_RESERVED = 0,       // always cleared
+        PERF_HEADER_FIRST_FEATURE = 1,
+        PERF_HEADER_TRACING_DATA = 1,
+        PERF_HEADER_BUILD_ID,
+        PERF_HEADER_HOSTNAME,
+        PERF_HEADER_OSRELEASE,
+        PERF_HEADER_VERSION,
+        PERF_HEADER_ARCH,
+        PERF_HEADER_NRCPUS,
+        PERF_HEADER_CPUDESC,
+        PERF_HEADER_CPUID,
+        PERF_HEADER_TOTAL_MEM,
+        PERF_HEADER_CMDLINE,
+        PERF_HEADER_EVENT_DESC,
+        PERF_HEADER_CPU_TOPOLOGY,
+        PERF_HEADER_NUMA_TOPOLOGY,
+        PERF_HEADER_BRANCH_STACK,
+        PERF_HEADER_PMU_MAPPINGS,
+        PERF_HEADER_GROUP_DESC,
+        PERF_HEADER_AUXTRACE,
+        PERF_HEADER_STAT,
+        PERF_HEADER_CACHE,
+        PERF_HEADER_SAMPLE_TIME,
+        PERF_HEADER_MEM_TOPOLOGY,
+        PERF_HEADER_CLOCKID,
+        PERF_HEADER_DIR_FORMAT,
+        PERF_HEADER_BPF_PROG_INFO,
+        PERF_HEADER_BPF_BTF,
+        PERF_HEADER_COMPRESSED,
+        PERF_HEADER_CPU_PMU_CAPS,
+        PERF_HEADER_CLOCK_DATA,
+        PERF_HEADER_HYBRID_TOPOLOGY,
+        PERF_HEADER_PMU_CAPS,
+        PERF_HEADER_LAST_FEATURE,
+    };
 
-    // HEADER_TRACING_DATA
-    bool m_parsedTracingData;
-    uint8_t m_tracingDataLongSize;
-    uint32_t m_tracingDataPageSize;
-    std::string_view m_headerPage; // Points into m_headers.
-    std::string_view m_headerEvent; // Points into m_headers.
-    std::vector<std::string_view> m_ftraces; // Points into m_headers.
-    std::map<uint32_t, PerfEventMetadata> m_metadataById; // Points into m_headers.
-    std::string_view m_kallsyms; // Points into m_headers.
-    std::string_view m_printk; // Points into m_headers.
-    std::string_view m_cmdline; // Points into m_headers.
+    struct PerfEventDesc
+    {
+        perf_event_attr const* attr;    // NULL for unknown id.
+        _Field_z_ char const* name;     // "" if no name available.
+    };
 
-public:
+    class PerfDataFile
+    {
+        struct perf_file_section;
+        struct perf_pipe_header;
+        struct perf_file_header;
 
-    PerfDataFile(PerfDataFile const&) = delete;
-    void operator=(PerfDataFile const&) = delete;
-    ~PerfDataFile() noexcept;
-    PerfDataFile() noexcept;
+        uint64_t m_filePos;
+        uint64_t m_fileLen;
+        uint64_t m_dataBeginFilePos;
+        uint64_t m_dataEndFilePos;
+        FILE* m_file;
+        std::vector<uint8_t> m_eventData;
+        std::vector<char> m_headers[32]; // Stored file-endian.
+        std::vector<std::unique_ptr<perf_event_attr>> m_attrsList; // Stored host-endian.
+        std::map<uint64_t, PerfEventDesc> m_eventDescById; // Points into m_attrsList and/or m_headers.
+        PerfByteReader m_byteReader;
+        int8_t m_sampleIdOffset; // -1 = unset, -2 = no id.
+        int8_t m_nonSampleIdOffset; // -1 = unset, -2 = no id.
+        int8_t m_commonTypeOffset; // -1 = unset, -2 = not available.
+        uint8_t m_commonTypeSize;
+        bool m_parsedHeaderEventDesc;
 
-    // Returns true if the currently-opened file is big-endian.
-    bool
-    FileBigEndian() const noexcept;
+        // HEADER_TRACING_DATA
+        bool m_parsedTracingData;
+        uint8_t m_tracingDataLongSize;
+        uint32_t m_tracingDataPageSize;
+        std::string_view m_headerPage; // Points into m_headers.
+        std::string_view m_headerEvent; // Points into m_headers.
+        std::vector<std::string_view> m_ftraces; // Points into m_headers.
+        std::map<uint32_t, PerfEventMetadata> m_metadataById; // Points into m_headers.
+        std::string_view m_kallsyms; // Points into m_headers.
+        std::string_view m_printk; // Points into m_headers.
+        std::string_view m_cmdline; // Points into m_headers.
 
-    // Returns PerfByteReader(FileBigEndian()).
-    PerfByteReader
-    ByteReader() const noexcept;
+    public:
 
-    // Returns the position within the input file of the event that will be
-    // read by the next call to ReadEvent().
-    // Returns UINT64_MAX after end-of-file or file error.
-    uint64_t
-    FilePos() const noexcept;
+        PerfDataFile(PerfDataFile const&) = delete;
+        void operator=(PerfDataFile const&) = delete;
+        ~PerfDataFile() noexcept;
+        PerfDataFile() noexcept;
 
-    // Returns the position within the input file of the first event.
-    uint64_t
-    DataBeginFilePos() const noexcept;
+        // Returns true if the currently-opened file is big-endian.
+        bool
+        FileBigEndian() const noexcept;
 
-    // If the input file was recorded in pipe mode, returns UINT64_MAX.
-    // Otherwise, returns the position within the input file immediately after
-    // the last event.
-    uint64_t
-    DataEndFilePos() const noexcept;
+        // Returns PerfByteReader(FileBigEndian()).
+        PerfByteReader
+        ByteReader() const noexcept;
 
-    // Returns the number of attribute records available from Attr().
-    uintptr_t
-    AttrCount() const noexcept;
+        // Returns the position within the input file of the event that will be
+        // read by the next call to ReadEvent().
+        // Returns UINT64_MAX after end-of-file or file error.
+        uint64_t
+        FilePos() const noexcept;
 
-    // Combined data from perf_file_header::attrs and PERF_RECORD_HEADER_ATTR.
-    // Requires attrIndex < AttrCount().
-    perf_event_attr const&
-    Attr(uintptr_t attrIndex) const noexcept;
+        // Returns the position within the input file of the first event.
+        uint64_t
+        DataBeginFilePos() const noexcept;
 
-    // Combined data from perf_file_header::attrs, PERF_RECORD_HEADER_ATTR,
-    // and HEADER_EVENT_DESC. Returns {NULL,""} for unknown id.
-    PerfEventDesc
-    EventDescById(uint64_t id) const noexcept;
+        // If the input file was recorded in pipe mode, returns UINT64_MAX.
+        // Otherwise, returns the position within the input file immediately after
+        // the last event.
+        uint64_t
+        DataEndFilePos() const noexcept;
 
-    // Returns the raw data from the specified header (file-endian, use ByteReader()
-    // to do byte-swapping as appropriate).
-    // Returns empty if the requested header was not loaded from the file.
-    std::string_view
-    Header(PerfHeaderIndex headerIndex) const noexcept;
+        // Returns the number of attribute records available from Attr().
+        uintptr_t
+        AttrCount() const noexcept;
 
-    // Closes the input file, if any.
-    void
-    Close() noexcept;
+        // Combined data from perf_file_header::attrs and PERF_RECORD_HEADER_ATTR.
+        // Requires attrIndex < AttrCount().
+        perf_event_attr const&
+        Attr(uintptr_t attrIndex) const noexcept;
 
-    // Closes the current input file (if any), then opens the specified
-    // perf.data file using fopen and reads the file header.
-    // If not a pipe-mode file, loads metadata. If a pipe-mode file, metadata
-    // will be loaded as the metadata events are encountered by ReadEvent.
-    // On successful return, the file will be positioned before the first event.
-    _Success_(return == 0) int
-    Open(_In_z_ char const* filePath) noexcept;
+        // Combined data from perf_file_header::attrs, PERF_RECORD_HEADER_ATTR,
+        // and HEADER_EVENT_DESC. Returns {NULL,""} for unknown id.
+        PerfEventDesc
+        EventDescById(uint64_t id) const noexcept;
 
-    // Closes the current input file (if any), then switches stdin to binary
-    // mode (Windows-only), then reads the file header from stdin. If stdin is
-    // not a pipe-mode file, returns an error. Metadata will be loaded as the
-    // metadata events are encountered by ReadEvent.
-    // On successful return, the file will be positioned before the first event.
-    _Success_(return == 0) int
-    OpenStdin() noexcept;
+        // Returns the raw data from the specified header (file-endian, use ByteReader()
+        // to do byte-swapping as appropriate).
+        // Returns empty if the requested header was not loaded from the file.
+        std::string_view
+        Header(PerfHeaderIndex headerIndex) const noexcept;
 
-    // Returns the event header (host-endian) followed by the raw data from the
-    // file (file-endian, use ByteReader() to do byte-swapping as appropriate).
-    //
-    // On success, sets *ppEventHeader to the event and returns 0.
-    // The returned pointer is valid until the next call to ReadEvent.
-    // 
-    // On end-of-file, sets *ppEventHeader to NULL and returns 0.
-    // 
-    // On error, sets *ppEventHeader to NULL and returns errno.
-    //
-    // For PERF_RECORD_HEADER_TRACING_DATA and PERF_RECORD_AUXTRACE, the extra
-    // data will be placed immediately after the event.
-    _Success_(return == 0) int
-    ReadEvent(_Outptr_result_maybenull_ perf_event_header const** ppEventHeader) noexcept;
+        // Closes the input file, if any.
+        void
+        Close() noexcept;
 
-    // Tries to get event information from the event's prefix. The prefix is
-    // usually present only for sample events. If the event prefix is not
-    // present, this function may return an error or it may succeed but return
-    // incorrect information. In general, only use this on events where
-    // pEventHeader->type == PERF_RECORD_SAMPLE.
-    _Success_(return == 0) int
-    GetSampleEventInfo(
-        _In_ perf_event_header const* pEventHeader,
-        _Out_ PerfSampleEventInfo* pInfo) const noexcept;
+        // Closes the current input file (if any), then opens the specified
+        // perf.data file using fopen and reads the file header.
+        // If not a pipe-mode file, loads metadata. If a pipe-mode file, metadata
+        // will be loaded as the metadata events are encountered by ReadEvent.
+        // On successful return, the file will be positioned before the first event.
+        _Success_(return == 0) int
+        Open(_In_z_ char const* filePath) noexcept;
 
-    // Tries to get event information from the event's suffix. The event suffix
-    // is usually present only for non-sample kernel-generated events.
-    // If the event suffix is not present, this function may return an error or
-    // it may succeed but return incorrect information. In general:
-    // - Only use this on events where pEventHeader->type != PERF_RECORD_SAMPLE
-    //   and pEventHeader->type < PERF_RECORD_USER_TYPE_START.
-    // - Only use this on events that come after the PERF_RECORD_FINISHED_INIT
-    //   event.
-    _Success_(return == 0) int
-    GetNonSampleEventInfo(
-        _In_ perf_event_header const* pEventHeader,
-        _Out_ PerfNonSampleEventInfo* pInfo) const noexcept;
+        // Closes the current input file (if any), then switches stdin to binary
+        // mode (Windows-only), then reads the file header from stdin. If stdin is
+        // not a pipe-mode file, returns an error. Metadata will be loaded as the
+        // metadata events are encountered by ReadEvent.
+        // On successful return, the file will be positioned before the first event.
+        _Success_(return == 0) int
+        OpenStdin() noexcept;
 
-private:
+        // Returns the event header (host-endian) followed by the raw data from the
+        // file (file-endian, use ByteReader() to do byte-swapping as appropriate).
+        //
+        // On success, sets *ppEventHeader to the event and returns 0.
+        // The returned pointer is valid until the next call to ReadEvent.
+        // 
+        // On end-of-file, sets *ppEventHeader to NULL and returns 0.
+        // 
+        // On error, sets *ppEventHeader to NULL and returns errno.
+        //
+        // For PERF_RECORD_HEADER_TRACING_DATA and PERF_RECORD_AUXTRACE, the extra
+        // data will be placed immediately after the event.
+        _Success_(return == 0) int
+        ReadEvent(_Outptr_result_maybenull_ perf_event_header const** ppEventHeader) noexcept;
 
-    _Success_(return == 0) int
-    LoadAttrs(perf_file_section const& attrs, uint64_t cbAttrAndIdSection64) noexcept;
+        // Tries to get event information from the event's prefix. The prefix is
+        // usually present only for sample events. If the event prefix is not
+        // present, this function may return an error or it may succeed but return
+        // incorrect information. In general, only use this on events where
+        // pEventHeader->type == PERF_RECORD_SAMPLE.
+        _Success_(return == 0) int
+        GetSampleEventInfo(
+            _In_ perf_event_header const* pEventHeader,
+            _Out_ PerfSampleEventInfo* pInfo) const noexcept;
 
-    _Success_(return == 0) int
-    LoadHeaders(perf_file_section const& data, uint64_t flags) noexcept;
+        // Tries to get event information from the event's suffix. The event suffix
+        // is usually present only for non-sample kernel-generated events.
+        // If the event suffix is not present, this function may return an error or
+        // it may succeed but return incorrect information. In general:
+        // - Only use this on events where pEventHeader->type != PERF_RECORD_SAMPLE
+        //   and pEventHeader->type < PERF_RECORD_USER_TYPE_START.
+        // - Only use this on events that come after the PERF_RECORD_FINISHED_INIT
+        //   event.
+        _Success_(return == 0) int
+        GetNonSampleEventInfo(
+            _In_ perf_event_header const* pEventHeader,
+            _Out_ PerfNonSampleEventInfo* pInfo) const noexcept;
 
-    void
-    ParseTracingData() noexcept;
+    private:
 
-    void
-    ParseHeaderEventDesc() noexcept;
+        _Success_(return == 0) int
+        LoadAttrs(perf_file_section const& attrs, uint64_t cbAttrAndIdSection64) noexcept;
 
-    _Success_(return == 0) int
-    GetSampleEventId(_In_ perf_event_header const* pEventHeader, _Out_ uint64_t* pId) const noexcept;
+        _Success_(return == 0) int
+        LoadHeaders(perf_file_section const& data, uint64_t flags) noexcept;
 
-    _Success_(return == 0) int
-    GetNonSampleEventId(_In_ perf_event_header const* pEventHeader, _Out_ uint64_t* pId) const noexcept;
+        void
+        ParseTracingData() noexcept;
 
-    _Success_(return == 0) int
-    AddAttr(
-        std::unique_ptr<perf_event_attr> pAttrPtr,
-        uint32_t cbAttrCopied,
-        _In_z_ char const* pName,
-        _In_reads_bytes_(cbIdsFileEndian) void const* pbIdsFileEndian,
-        uintptr_t cbIdsFileEndian) noexcept(false);
+        void
+        ParseHeaderEventDesc() noexcept;
 
-    template<class SizeType>
-    _Success_(return == 0) int
-    ReadPostEventData(uint16_t eventSizeFromHeader) noexcept;
+        _Success_(return == 0) int
+        GetSampleEventId(_In_ perf_event_header const* pEventHeader, _Out_ uint64_t* pId) const noexcept;
 
-    bool
-    EnsureEventDataSize(uint32_t minSize) noexcept;
+        _Success_(return == 0) int
+        GetNonSampleEventId(_In_ perf_event_header const* pEventHeader, _Out_ uint64_t* pId) const noexcept;
 
-    // Note: leaves filePos at EOF.
-    _Success_(return == 0) int
-    UpdateFileLen() noexcept;
+        _Success_(return == 0) int
+        AddAttr(
+            std::unique_ptr<perf_event_attr> pAttrPtr,
+            uint32_t cbAttrCopied,
+            _In_z_ char const* pName,
+            _In_reads_bytes_(cbIdsFileEndian) void const* pbIdsFileEndian,
+            uintptr_t cbIdsFileEndian) noexcept(false);
 
-    bool
-    SectionValid(perf_file_section const& section) const noexcept;
+        template<class SizeType>
+        _Success_(return == 0) int
+        ReadPostEventData(uint16_t eventSizeFromHeader) noexcept;
 
-    // Returns 0 (success), EIO (fread error), or EPIPE (eof).
-    _Success_(return == 0) int
-    FileRead(_Out_writes_bytes_all_(cb) void* p, uintptr_t cb) noexcept;
+        bool
+        EnsureEventDataSize(uint32_t minSize) noexcept;
 
-    _Success_(return == 0) int
-    FileSeek(uint64_t filePos) noexcept;
+        // Note: leaves filePos at EOF.
+        _Success_(return == 0) int
+        UpdateFileLen() noexcept;
 
-    // Returns 0 (success), EIO (fread error), EPIPE (eof), or others.
-    _Success_(return == 0) int
-    FileSeekAndRead(uint64_t filePos, _Out_writes_bytes_all_(cb) void* p, uintptr_t cb) noexcept;
-};
+        bool
+        SectionValid(perf_file_section const& section) const noexcept;
+
+        // Returns 0 (success), EIO (fread error), or EPIPE (eof).
+        _Success_(return == 0) int
+        FileRead(_Out_writes_bytes_all_(cb) void* p, uintptr_t cb) noexcept;
+
+        _Success_(return == 0) int
+        FileSeek(uint64_t filePos) noexcept;
+
+        // Returns 0 (success), EIO (fread error), EPIPE (eof), or others.
+        _Success_(return == 0) int
+        FileSeekAndRead(uint64_t filePos, _Out_writes_bytes_all_(cb) void* p, uintptr_t cb) noexcept;
+    };
+}
+// namespace tracepoint_decode
 
 #endif // _included_PerfDataFile_h

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventAbi.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventAbi.h
@@ -749,14 +749,18 @@ struct perf_event_header {
     void ByteSwap() noexcept;
 };
 
-// Returns a string for the PERF_TYPE_* enum value, e.g. "HARDWARE".
-// If enum is not recognized, formats decimal value into and returns scratch.
-_Ret_z_ char const*
-PerfEnumToString(perf_type_id value, _Pre_cap_(11) char* scratch) noexcept;
+namespace tracepoint_decode
+{
+    // Returns a string for the PERF_TYPE_* enum value, e.g. "HARDWARE".
+    // If enum is not recognized, formats decimal value into and returns scratch.
+    _Ret_z_ char const*
+    PerfEnumToString(perf_type_id value, _Pre_cap_(11) char* scratch) noexcept;
 
-// Returns a string for the PERF_RECORD_* enum value, e.g. "SAMPLE".
-// If enum is not recognized, formats decimal value into and returns scratch.
-_Ret_z_ char const*
-PerfEnumToString(perf_event_type value, _Pre_cap_(11) char* scratch) noexcept;
+    // Returns a string for the PERF_RECORD_* enum value, e.g. "SAMPLE".
+    // If enum is not recognized, formats decimal value into and returns scratch.
+    _Ret_z_ char const*
+    PerfEnumToString(perf_event_type value, _Pre_cap_(11) char* scratch) noexcept;
+}
+// namespace tracepoint_decode
 
 #endif // _included_PerfEventAbi_h

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
@@ -17,42 +17,46 @@
 #define _Field_size_bytes_(size)
 #endif
 
-// Forward declaration from PerfEventMetadata.h:
-class PerfEventMetadata;
-
 // Forward declaration from PerfEventAbi.h or linux/uapi/linux/perf_event.h:
 struct perf_event_attr;
 
-struct PerfSampleEventInfo
+namespace tracepoint_decode
 {
-    uint64_t id;                            // Always valid if GetSampleEventInfo succeeded.
-    perf_event_attr const* attr;            // Always valid if GetSampleEventInfo succeeded.
-    _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
-    uint64_t sample_type;                   // Bit set if corresponding info present in event.
-    uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
-    uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
-    uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
-    uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
-    uint64_t ip;                            // Valid if sample_type & PERF_SAMPLE_IP.
-    uint64_t addr;                          // Valid if sample_type & PERF_SAMPLE_ADDR.
-    uint64_t period;                        // Valid if sample_type & PERF_SAMPLE_PERIOD.
-    uint64_t const* read_values;            // Valid if sample_type & PERF_SAMPLE_READ. Points into event.
-    uint64_t const* callchain;              // Valid if sample_type & PERF_SAMPLE_CALLCHAIN. Points into event.
-    PerfEventMetadata const* raw_meta;      // Valid if sample_type & PERF_SAMPLE_RAW. NULL if event unknown.
-    _Field_size_bytes_(raw_data_size) void const* raw_data; // Valid if sample_type & PERF_SAMPLE_RAW. Points into event.
-    uintptr_t raw_data_size;                   // Valid if sample_type & PERF_SAMPLE_RAW. Size of raw_data.
-};
+    // Forward declaration from PerfEventMetadata.h:
+    class PerfEventMetadata;
 
-struct PerfNonSampleEventInfo
-{
-    uint64_t id;                            // Always valid if GetNonSampleEventInfo succeeded.
-    perf_event_attr const* attr;            // Always valid if GetNonSampleEventInfo succeeded.
-    _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
-    uint64_t sample_type;                   // Bit set if corresponding info present in event.
-    uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
-    uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
-    uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
-    uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
-};
+    struct PerfSampleEventInfo
+    {
+        uint64_t id;                            // Always valid if GetSampleEventInfo succeeded.
+        perf_event_attr const* attr;            // Always valid if GetSampleEventInfo succeeded.
+        _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
+        uint64_t sample_type;                   // Bit set if corresponding info present in event.
+        uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
+        uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
+        uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
+        uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
+        uint64_t ip;                            // Valid if sample_type & PERF_SAMPLE_IP.
+        uint64_t addr;                          // Valid if sample_type & PERF_SAMPLE_ADDR.
+        uint64_t period;                        // Valid if sample_type & PERF_SAMPLE_PERIOD.
+        uint64_t const* read_values;            // Valid if sample_type & PERF_SAMPLE_READ. Points into event.
+        uint64_t const* callchain;              // Valid if sample_type & PERF_SAMPLE_CALLCHAIN. Points into event.
+        PerfEventMetadata const* raw_meta;      // Valid if sample_type & PERF_SAMPLE_RAW. NULL if event unknown.
+        _Field_size_bytes_(raw_data_size) void const* raw_data; // Valid if sample_type & PERF_SAMPLE_RAW. Points into event.
+        uintptr_t raw_data_size;                   // Valid if sample_type & PERF_SAMPLE_RAW. Size of raw_data.
+    };
+
+    struct PerfNonSampleEventInfo
+    {
+        uint64_t id;                            // Always valid if GetNonSampleEventInfo succeeded.
+        perf_event_attr const* attr;            // Always valid if GetNonSampleEventInfo succeeded.
+        _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
+        uint64_t sample_type;                   // Bit set if corresponding info present in event.
+        uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
+        uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
+        uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
+        uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
+    };
+}
+// namespace tracepoint_decode
 
 #endif // _included_PerfEventInfo_h

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventMetadata.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventMetadata.h
@@ -16,205 +16,209 @@
 #define _In_reads_bytes_(cb)
 #endif
 
-enum PerfFieldElementSize : uint8_t
+namespace tracepoint_decode
 {
-    PerfFieldElementSize8  = 0, // sizeof(uint8_t)  == 1 << PerfFieldElementSize8
-    PerfFieldElementSize16 = 1, // sizeof(uint16_t) == 1 << PerfFieldElementSize16
-    PerfFieldElementSize32 = 2, // sizeof(uint32_t) == 1 << PerfFieldElementSize32
-    PerfFieldElementSize64 = 3, // sizeof(uint64_t) == 1 << PerfFieldElementSize64
-};
+    enum PerfFieldElementSize : uint8_t
+    {
+        PerfFieldElementSize8  = 0, // sizeof(uint8_t)  == 1 << PerfFieldElementSize8
+        PerfFieldElementSize16 = 1, // sizeof(uint16_t) == 1 << PerfFieldElementSize16
+        PerfFieldElementSize32 = 2, // sizeof(uint32_t) == 1 << PerfFieldElementSize32
+        PerfFieldElementSize64 = 3, // sizeof(uint64_t) == 1 << PerfFieldElementSize64
+    };
 
-enum PerfFieldFormat : uint8_t
-{
-    PerfFieldFormatNone,    // Type unknown (treat as binary blob)
-    PerfFieldFormatUnsigned,// u8, u16, u32, u64, etc.
-    PerfFieldFormatSigned,  // s8, s16, s32, s64, etc.
-    PerfFieldFormatHex,     // unsigned long, pointers
-    PerfFieldFormatString,  // char, char[]
-};
+    enum PerfFieldFormat : uint8_t
+    {
+        PerfFieldFormatNone,    // Type unknown (treat as binary blob)
+        PerfFieldFormatUnsigned,// u8, u16, u32, u64, etc.
+        PerfFieldFormatSigned,  // s8, s16, s32, s64, etc.
+        PerfFieldFormatHex,     // unsigned long, pointers
+        PerfFieldFormatString,  // char, char[]
+    };
 
-enum PerfFieldArray : uint8_t
-{
-    PerfFieldArrayNone,     // e.g. "char val"
-    PerfFieldArrayFixed,    // e.g. "char val[12]"
-    PerfFieldArrayDynamic,  // e.g. "__data_loc char val[]", value = (len << 16) | offset.
-    PerfFieldArrayRelDyn,   // e.g. "__rel_loc char val[]", value = (len << 16) | relativeOffset.
-};
+    enum PerfFieldArray : uint8_t
+    {
+        PerfFieldArrayNone,     // e.g. "char val"
+        PerfFieldArrayFixed,    // e.g. "char val[12]"
+        PerfFieldArrayDynamic,  // e.g. "__data_loc char val[]", value = (len << 16) | offset.
+        PerfFieldArrayRelDyn,   // e.g. "__rel_loc char val[]", value = (len << 16) | relativeOffset.
+    };
 
-class PerfFieldMetadata
-{
-    static constexpr std::string_view noname = std::string_view("noname", 6);
+    class PerfFieldMetadata
+    {
+        static constexpr std::string_view noname = std::string_view("noname", 6);
 
-    std::string_view m_name;     // deduced from field, e.g. "my_field".
-    std::string_view m_field;    // value of "field:" property, e.g. "char my_field[8]".
-    uint16_t m_offset;           // value of "offset:" property.
-    uint16_t m_size;             // value of "size:" property.
-    uint16_t m_fixedArrayCount;  // deduced from field, size.
-    PerfFieldElementSize m_elementSize; // deduced from field, size.
-    PerfFieldFormat m_format;    // deduced from field, size, signed.
-    PerfFieldArray m_array;      // deduced from field, size.
+        std::string_view m_name;     // deduced from field, e.g. "my_field".
+        std::string_view m_field;    // value of "field:" property, e.g. "char my_field[8]".
+        uint16_t m_offset;           // value of "offset:" property.
+        uint16_t m_size;             // value of "size:" property.
+        uint16_t m_fixedArrayCount;  // deduced from field, size.
+        PerfFieldElementSize m_elementSize; // deduced from field, size.
+        PerfFieldFormat m_format;    // deduced from field, size, signed.
+        PerfFieldArray m_array;      // deduced from field, size.
 
-public:
+    public:
 
-    // Parses a line of the "format:" section of an event's "format" file. The
-    // formatLine string will generally look like
-    // "[whitespace?]field:[declaration]; offset:[number]; size:[number]; ...".
-    //
-    // If "field:" is non-empty, "offset:" is a valid unsigned integer, and
-    // "size:" is a valid unsigned integer, this returns
-    // PerfFieldMetadata(field, offset, size, isSigned). Otherwise, this
-    // returns PerfFieldMetadata().
-    //
-    // Stored strings will point into formatLine, so the formatLine string must
-    // outlive this object.
-    static PerfFieldMetadata
-    Parse(
-        bool longSize64, // true if sizeof(long) == 8, false if sizeof(long) == 4.
-        std::string_view formatLine) noexcept;
+        // Parses a line of the "format:" section of an event's "format" file. The
+        // formatLine string will generally look like
+        // "[whitespace?]field:[declaration]; offset:[number]; size:[number]; ...".
+        //
+        // If "field:" is non-empty, "offset:" is a valid unsigned integer, and
+        // "size:" is a valid unsigned integer, this returns
+        // PerfFieldMetadata(field, offset, size, isSigned). Otherwise, this
+        // returns PerfFieldMetadata().
+        //
+        // Stored strings will point into formatLine, so the formatLine string must
+        // outlive this object.
+        static PerfFieldMetadata
+        Parse(
+            bool longSize64, // true if sizeof(long) == 8, false if sizeof(long) == 4.
+            std::string_view formatLine) noexcept;
 
-    // Same as PerfFieldMetadata({}, 0, 0)
-    constexpr
-    PerfFieldMetadata() noexcept
-        : m_name(noname)
-        , m_field()
-        , m_offset()
-        , m_size()
-        , m_fixedArrayCount()
-        , m_elementSize()
-        , m_format()
-        , m_array() {}
+        // Same as PerfFieldMetadata({}, 0, 0)
+        constexpr
+        PerfFieldMetadata() noexcept
+            : m_name(noname)
+            , m_field()
+            , m_offset()
+            , m_size()
+            , m_fixedArrayCount()
+            , m_elementSize()
+            , m_format()
+            , m_array() {}
 
-    // Initializes Field, Offset, and Size properties exactly as specified.
-    // Deduces the other properties. The isSigned parameter should be -1 if the
-    // "signed:" property is not present in the format line.
-    PerfFieldMetadata(
-        bool longSize64, // true if sizeof(long) == 8, false if sizeof(long) == 4.
-        std::string_view field,
-        uint16_t offset,
-        uint16_t size,
-        int8_t isSigned = -1) noexcept;
+        // Initializes Field, Offset, and Size properties exactly as specified.
+        // Deduces the other properties. The isSigned parameter should be -1 if the
+        // "signed:" property is not present in the format line.
+        PerfFieldMetadata(
+            bool longSize64, // true if sizeof(long) == 8, false if sizeof(long) == 4.
+            std::string_view field,
+            uint16_t offset,
+            uint16_t size,
+            int8_t isSigned = -1) noexcept;
 
-    // Returns the field name, e.g. "my_field". Never empty. (Deduced from
-    // "field:".)
-    constexpr std::string_view
-    Name() const noexcept { return m_name; }
+        // Returns the field name, e.g. "my_field". Never empty. (Deduced from
+        // "field:".)
+        constexpr std::string_view
+        Name() const noexcept { return m_name; }
 
-    // Returns the field declaration, e.g. "char my_field[8]".
-    // (Parsed directly from "field:".)
-    constexpr std::string_view
-    Field() const noexcept { return m_field; }
+        // Returns the field declaration, e.g. "char my_field[8]".
+        // (Parsed directly from "field:".)
+        constexpr std::string_view
+        Field() const noexcept { return m_field; }
 
-    // Returns the byte offset of the start of the field data from the start of
-    // the event raw data. (Parsed directly from "offset:".)
-    constexpr uint16_t
-    Offset() const noexcept { return m_offset; }
+        // Returns the byte offset of the start of the field data from the start of
+        // the event raw data. (Parsed directly from "offset:".)
+        constexpr uint16_t
+        Offset() const noexcept { return m_offset; }
 
-    // Returns the byte size of the field data. (Parsed directly from "size:".)
-    constexpr uint16_t
-    Size() const noexcept { return m_size; }
+        // Returns the byte size of the field data. (Parsed directly from "size:".)
+        constexpr uint16_t
+        Size() const noexcept { return m_size; }
 
-    // Returns the number of elements in this field. Meaningful only when
-    // Array() == Fixed. (Deduced from "field:" and "size:".)
-    constexpr uint16_t
-    FixedArrayCount() const noexcept { return m_fixedArrayCount; }
+        // Returns the number of elements in this field. Meaningful only when
+        // Array() == Fixed. (Deduced from "field:" and "size:".)
+        constexpr uint16_t
+        FixedArrayCount() const noexcept { return m_fixedArrayCount; }
 
-    // Returns the size of each element in this field. (Deduced from "field:"
-    // and "size:".)
-    constexpr PerfFieldElementSize
-    ElementSize() const noexcept { return m_elementSize; }
+        // Returns the size of each element in this field. (Deduced from "field:"
+        // and "size:".)
+        constexpr PerfFieldElementSize
+        ElementSize() const noexcept { return m_elementSize; }
 
-    // Returns the format of the field. (Deduced from "field:" and "signed:".)
-    constexpr PerfFieldFormat
-    Format() const noexcept { return m_format; }
+        // Returns the format of the field. (Deduced from "field:" and "signed:".)
+        constexpr PerfFieldFormat
+        Format() const noexcept { return m_format; }
 
-    // Returns whether this is an array, and if so, how the array length should
-    // be determined. (Deduced from "field:" and "size:".)
-    constexpr PerfFieldArray
-    Array() const noexcept { return m_array; }
+        // Returns whether this is an array, and if so, how the array length should
+        // be determined. (Deduced from "field:" and "size:".)
+        constexpr PerfFieldArray
+        Array() const noexcept { return m_array; }
 
-    // Given the event's raw data (e.g. PerfSampleEventInfo::raw_data), return
-    // this field's raw data. Returns empty for error (e.g. out of bounds).
-    //
-    // Does not do any byte-swapping. This method uses fileBigEndian to resolve
-    // data_loc and rel_loc references, not to fix up the field data.
-    // 
-    // Note that in some cases, the size returned by GetFieldBytes may be
-    // different from the value returned by Size():
-    //
-    // - If eventRawDataSize < Offset() + Size(), returns {}.
-    // - If Size() == 0, returns all data from offset to the end of the event,
-    //   i.e. it returns eventRawDataSize - Offset() bytes.
-    // - If Array() is Dynamic or RelDyn, the returned size depends on the
-    //   event contents.
-    std::string_view
-    GetFieldBytes(
-        _In_reads_bytes_(eventRawDataSize) void const* eventRawData,
-        uintptr_t eventRawDataSize,
-        bool fileBigEndian) const noexcept;
-};
+        // Given the event's raw data (e.g. PerfSampleEventInfo::raw_data), return
+        // this field's raw data. Returns empty for error (e.g. out of bounds).
+        //
+        // Does not do any byte-swapping. This method uses fileBigEndian to resolve
+        // data_loc and rel_loc references, not to fix up the field data.
+        // 
+        // Note that in some cases, the size returned by GetFieldBytes may be
+        // different from the value returned by Size():
+        //
+        // - If eventRawDataSize < Offset() + Size(), returns {}.
+        // - If Size() == 0, returns all data from offset to the end of the event,
+        //   i.e. it returns eventRawDataSize - Offset() bytes.
+        // - If Array() is Dynamic or RelDyn, the returned size depends on the
+        //   event contents.
+        std::string_view
+        GetFieldBytes(
+            _In_reads_bytes_(eventRawDataSize) void const* eventRawData,
+            uintptr_t eventRawDataSize,
+            bool fileBigEndian) const noexcept;
+    };
 
-class PerfEventMetadata
-{
-    std::string_view m_systemName;
-    std::string_view m_name;
-    std::string_view m_printFmt;
-    std::vector<PerfFieldMetadata> m_fields;
-    uint32_t m_id; // From common_type; not the same as the perf_event_attr::id or PerfSampleEventInfo::id.
-    uint16_t m_commonFieldCount; // fields[common_field_count] is the first user field.
-    bool m_hasEventHeader; // true if first user field is named "eventheader_flags".
+    class PerfEventMetadata
+    {
+        std::string_view m_systemName;
+        std::string_view m_name;
+        std::string_view m_printFmt;
+        std::vector<PerfFieldMetadata> m_fields;
+        uint32_t m_id; // From common_type; not the same as the perf_event_attr::id or PerfSampleEventInfo::id.
+        uint16_t m_commonFieldCount; // fields[common_field_count] is the first user field.
+        bool m_hasEventHeader; // true if first user field is named "eventheader_flags".
 
-public:
+    public:
 
-    ~PerfEventMetadata();
-    PerfEventMetadata() noexcept;
+        ~PerfEventMetadata();
+        PerfEventMetadata() noexcept;
 
-    // Returns the value of the systemName parameter, e.g. "user_events".
-    constexpr std::string_view
-    SystemName() const noexcept { return m_systemName; }
+        // Returns the value of the systemName parameter, e.g. "user_events".
+        constexpr std::string_view
+        SystemName() const noexcept { return m_systemName; }
 
-    // Returns the value of the "name:" property, e.g. "my_event".
-    constexpr std::string_view
-    Name() const noexcept { return m_name; }
+        // Returns the value of the "name:" property, e.g. "my_event".
+        constexpr std::string_view
+        Name() const noexcept { return m_name; }
 
-    // Returns the value of the "print fmt:" property.
-    constexpr std::string_view
-    PrintFmt() const noexcept { return m_printFmt; }
+        // Returns the value of the "print fmt:" property.
+        constexpr std::string_view
+        PrintFmt() const noexcept { return m_printFmt; }
 
-    // Returns the fields from the "format:" property.
-    constexpr std::vector<PerfFieldMetadata> const&
-    Fields() const noexcept { return m_fields; }
+        // Returns the fields from the "format:" property.
+        constexpr std::vector<PerfFieldMetadata> const&
+        Fields() const noexcept { return m_fields; }
 
-    // Returns the value of the "ID:" property. Note that this value gets
-    // matched against the "common_type" field of an event, not the id field
-    // of perf_event_attr or PerfSampleEventInfo.
-    constexpr uint32_t
-    Id() const noexcept { return m_id; }
+        // Returns the value of the "ID:" property. Note that this value gets
+        // matched against the "common_type" field of an event, not the id field
+        // of perf_event_attr or PerfSampleEventInfo.
+        constexpr uint32_t
+        Id() const noexcept { return m_id; }
 
-    // Returns the number of "common_*" fields at the start of the event.
-    // User fields start at this index. At present, there are 4 common fields:
-    // common_type, common_flags, common_preempt_count, common_pid.
-    constexpr uint16_t
-    CommonFieldCount() const noexcept { return m_commonFieldCount; }
+        // Returns the number of "common_*" fields at the start of the event.
+        // User fields start at this index. At present, there are 4 common fields:
+        // common_type, common_flags, common_preempt_count, common_pid.
+        constexpr uint16_t
+        CommonFieldCount() const noexcept { return m_commonFieldCount; }
 
-    // Returns true if the first user field is named "eventheader_flags".
-    constexpr bool
-    HasEventHeader() const noexcept { return m_hasEventHeader; }
+        // Returns true if the first user field is named "eventheader_flags".
+        constexpr bool
+        HasEventHeader() const noexcept { return m_hasEventHeader; }
 
-    // Sets all properties of this object to {} values.
-    void
-    Clear() noexcept;
+        // Sets all properties of this object to {} values.
+        void
+        Clear() noexcept;
 
-    // Parses an event's "format" file and sets the fields of this object based
-    // on the results. Returns true if "ID:" is a valid unsigned integer and
-    // "name:" is non-empty, returns true. Throws bad_alloc for out-of-memory.
-    //
-    // Stored strings will point into systemName and formatFileContents, so
-    // those strings must outlive this object.
-    bool
-    Parse(
-        bool longSize64, // true if sizeof(long) == 8, false if sizeof(long) == 4.
-        std::string_view systemName,
-        std::string_view formatFileContents) noexcept(false); // May throw bad_alloc.
-};
+        // Parses an event's "format" file and sets the fields of this object based
+        // on the results. Returns true if "ID:" is a valid unsigned integer and
+        // "name:" is non-empty, returns true. Throws bad_alloc for out-of-memory.
+        //
+        // Stored strings will point into systemName and formatFileContents, so
+        // those strings must outlive this object.
+        bool
+        Parse(
+            bool longSize64, // true if sizeof(long) == 8, false if sizeof(long) == 4.
+            std::string_view systemName,
+            std::string_view formatFileContents) noexcept(false); // May throw bad_alloc.
+    };
+}
+// namespace tracepoint_decode
 
 #endif // _included_PerfEventMetadata_h

--- a/libtracepoint-decode-cpp/src/PerfByteReader.cpp
+++ b/libtracepoint-decode-cpp/src/PerfByteReader.cpp
@@ -17,6 +17,8 @@ static bool constexpr HostIsBigEndian = false;
 static bool constexpr HostIsBigEndian = __BYTE_ORDER == __BIG_ENDIAN;
 #endif // _WIN32
 
+using namespace tracepoint_decode;
+
 PerfByteReader::PerfByteReader() noexcept
     : m_bigEndian(HostIsBigEndian) {}
 

--- a/libtracepoint-decode-cpp/src/PerfDataFile.cpp
+++ b/libtracepoint-decode-cpp/src/PerfDataFile.cpp
@@ -13,6 +13,7 @@
 #include <optional>
 
 using namespace std::string_view_literals;
+using namespace tracepoint_decode;
 
 #ifdef _WIN32
 #include <io.h>     // _setmode

--- a/libtracepoint-decode-cpp/src/PerfEventAbi.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventAbi.cpp
@@ -14,6 +14,8 @@
 #include <byteswap.h>
 #endif // _WIN32
 
+using namespace tracepoint_decode;
+
 template<class T, unsigned N>
 static constexpr unsigned
 ArrayCount(T(&)[N]) noexcept

--- a/libtracepoint-decode-cpp/src/PerfEventMetadata.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventMetadata.cpp
@@ -9,6 +9,7 @@
 #include <string.h>
 
 using namespace std::string_view_literals;
+using namespace tracepoint_decode;
 
 #ifndef _In_
 #define _In_


### PR DESCRIPTION
Move the C++ decode libraries into namespaces:

- namespace `eventheader_decode` for `libeventheader-decode-cpp`
- namespace `tracepoint_decode` for `libtracepoint-decode-cpp`

Also, set `/std:cpp17` on a per-module basis instead of via global `set` in `CMakeLists.txt`.