### PR TITLE
Fix decoding of byte arrays

### DIFF
--- a/libeventheader-tracepoint/include/CMakeLists.txt
+++ b/libeventheader-tracepoint/include/CMakeLists.txt
@@ -7,17 +7,22 @@ project(eventheader-tracepoint-headers
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
+list(APPEND EVENTHEADER_HEADERS
+    "${PROJECT_SOURCE_DIR}/eventheader/eventheader.h")
+
+if(NOT WIN32)
+    list(APPEND EVENTHEADER_HEADERS
+    "${PROJECT_SOURCE_DIR}/eventheader/eventheader-tracepoint.h"
+    "${PROJECT_SOURCE_DIR}/eventheader/EventHeaderDynamic.h"
+    "${PROJECT_SOURCE_DIR}/eventheader/TraceLoggingProvider.h")
+endif()
+
 # eventheader-headers = EVENTHEADER_HEADERS
 add_library(eventheader-headers INTERFACE)
 target_include_directories(eventheader-headers
     INTERFACE
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-set(EVENTHEADER_HEADERS
-    "${PROJECT_SOURCE_DIR}/eventheader/eventheader.h"
-    "${PROJECT_SOURCE_DIR}/eventheader/EventHeaderDynamic.h"
-    "${PROJECT_SOURCE_DIR}/eventheader/eventheader-tracepoint.h"
-    "${PROJECT_SOURCE_DIR}/eventheader/TraceLoggingProvider.h")
 set_target_properties(eventheader-headers PROPERTIES
     PUBLIC_HEADER "${EVENTHEADER_HEADERS}")
 install(TARGETS eventheader-headers

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfByteReader.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfByteReader.h
@@ -91,7 +91,7 @@ namespace tracepoint_decode
             if constexpr (sizeof(ValType) == sizeof(uint8_t))
             {
                 ValType v;
-                memcpy(&v, &pSrc, sizeof(v));
+                memcpy(&v, pSrc, sizeof(v));
                 return v;
             }
             else if constexpr (sizeof(ValType) == sizeof(uint16_t))

--- a/libtracepoint/include/CMakeLists.txt
+++ b/libtracepoint/include/CMakeLists.txt
@@ -7,16 +7,22 @@ project(tracepoint-headers
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
+list(APPEND TRACEPOINT_HEADERS
+    "${PROJECT_SOURCE_DIR}/tracepoint/tracepoint.h")
+
+if(NOT WIN32)
+    list(APPEND TRACEPOINT_HEADERS
+    "${PROJECT_SOURCE_DIR}/tracepoint/tracepoint-impl.h"
+    "${PROJECT_SOURCE_DIR}/tracepoint/tracepoint-provider.h"
+    "${PROJECT_SOURCE_DIR}/tracepoint/tracepoint-state.h")
+endif()
+
 # tracepoint-headers = TRACEPOINT_HEADERS
 add_library(tracepoint-headers INTERFACE)
 target_include_directories(tracepoint-headers
     INTERFACE
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-set(TRACEPOINT_HEADERS
-    "${PROJECT_SOURCE_DIR}/tracepoint/tracepoint.h"
-    "${PROJECT_SOURCE_DIR}/tracepoint/tracepoint-impl.h"
-    "${PROJECT_SOURCE_DIR}/tracepoint/tracepoint-state.h")
 set_target_properties(tracepoint-headers PROPERTIES
     PUBLIC_HEADER "${TRACEPOINT_HEADERS}")
 install(TARGETS tracepoint-headers


### PR DESCRIPTION
The decode-perf tool is showing garbage data when decoding byte arrays. This occurs because it is printing the value of `&ptr` instead of `*ptr`.

Also some minor fixes in the CMake build "install" step:

- For Windows builds, don't publish headers that aren't relevant for Windows.
- The `tracepoint-provider.h` header wasn't getting published, so fix that.