### PR TITLE
TracepointSession - cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,37 @@
 # Libraries for Linux Tracepoints and user_events
 
-This repository contains libraries for using the
-[user_events](https://docs.kernel.org/trace/user_events.html) facility to
-generate Linux Tracepoints from user mode.
+This repository contains libraries for collecting and decoding
+[Linux Tracepoint](https://www.kernel.org/doc/html/latest/trace/tracepoints.html)
+events and for generating Tracepoint events from user mode using the
+[user_events](https://docs.kernel.org/trace/user_events.html) facility.
 
 ## Overview
 
 - [libtracepoint](libtracepoint) -
   low-level C/C++ tracing interface. Designed to support replacement at
-  link-time if a different implementation is needed.
+  link-time if a different implementation is needed (e.g. for testing).
   - [Default implementation](libtracepoint/src/tracepoint.c)
     writes directly to the Linux `user_events` facility.
   - [tracepoint-provider.h](libtracepoint/include/tracepoint/tracepoint-provider.h) -
     a developer-friendly C/C++ API for writing tracepoint events to any
     implementation of the tracepoint interface.
+- [libtracepoint-control-cpp](libtracepoint-control-cpp) -
+  C++ library for controlling a tracepoint event collection session.
+  - `TracingSession.h` implements an event collection session that can
+    collect tracepoint events and enumerate the events that the session has
+    collected.
+  - `TracingPath.h` has functions for finding the `/sys/kernel/tracing`
+    mount point and reading `format` files.
+  - `TracingCache.h` implements a cache for tracking parsed `format` files
+    based on system+name or by `common_type` id.
+- [libtracepoint-decode-cpp](libtracepoint-decode-cpp) -
+  C++ library for decoding tracepoints. Works on both Linux and Windows.
+  - `PerfDataFile.h` defines the `PerfDataFile` class that decodes
+    `perf.data` files.
+  - `PerfEventInfo.h` defines the `PerfSampleEventInfo` and
+    `PerfNonSampleEventInfo` structures for raw event information.
+  - `PerfEventMetadata.h` defines classes for parsing ftrace event metadata
+    information.
 - [libeventheader-tracepoint](libeventheader-tracepoint) -
   `eventheader` envelope that supports extended attributes including severity
   level and optional field type information.
@@ -24,23 +42,6 @@ generate Linux Tracepoints from user mode.
     C++ API for writing runtime-defined `eventheader`-encapsulated events,
     intended for use as an implementation layer for a higher-level API like
     OpenTelemetry.
-- [libtracepoint-control-cpp](libtracepoint-control-cpp) -
-  C++ library for controlling a tracepoint collection session.
-  - `TracingPath.h` has functions for finding the `/sys/kernel/tracing`
-    mount point and reading `format` files.
-  - `TracingCache.h` implements a cache for tracking parsed `format` files
-    based on system+name or by `common_type` id.
-  - `TracingSession.h` implements session control (add/remove tracepoints
-    from a session) and data collection (enumerate the events that the
-    session has collected).
-- [libtracepoint-decode-cpp](libtracepoint-decode-cpp) -
-  C++ library for decoding tracepoints. Works on both Linux and Windows.
-  - `PerfEventInfo.h` defines the `PerfSampleEventInfo` and
-    `PerfNonSampleEventInfo` structures for raw event information.
-  - `PerfDataFile.h` defines the `PerfDataFile` class that decodes
-    `perf.data` files.
-  - `PerfEventMetadata.h` defines classes for parsing ftrace event metadata
-    information.
 - [libeventheader-decode-cpp](libeventheader-decode-cpp) -
   C++ library for decoding events that use the `eventheader` envelope.
   - `EventEnumerator` class parses an event into fields.

--- a/README.md
+++ b/README.md
@@ -80,14 +80,18 @@ events and for generating Tracepoint events from user mode using the
     [EventHeaderDynamic.h](libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h)
     to generate eventheader-enabled Tracepoint events that are runtime-dynamic.
     (Link with `libtracepoint` and `libeventheader-tracepoint`.)
-  - Rust middle-layer APIs (e.g. an OpenTelemetry exporter) can use the
-    [eventheader_dynamic](rust/eventheader_dynamic/README.md) crate
-    to generate eventheader-enabled Tracepoint events that are defined at
-    compile-time.
-- Running as a privileged user, use the Linux
+  - Rust programs can use the [eventheader](rust/eventheader/README.md) or
+    [eventheader_dynamic](rust/eventheader_dynamic/README.md) crates
+    to generate eventheader-enabled Tracepoint events.
+- To collect events in a C++ program, use the
+  [libtracepoint-control-cpp](libtracepoint-control-cpp). Note that your
+  program must run as a privileged user because access to the event collection
+  system is restricted by default.
+- To collect events without writing C++ code, use the Linux
   [`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) tool
   to collect events to a `perf.data` file, e.g.
-  `perf record -e user_events:MyEvent1,user_events:MyEvent2`.
+  `perf record -e user_events:MyEvent1,user_events:MyEvent2`. Note that you
+  must run the `perf` tool as a privileged user to collect events.
   - The `perf` tool binary is typically available as part of the `linux-perf`
     package (e.g. can be installed by `apt install linux-perf`). However, this
     package installs a `perf_VERSION` binary rather than a `perf` binary, so
@@ -113,9 +117,14 @@ events and for generating Tracepoint events from user mode using the
   - For eventheader-enabled Tracepoint events, you can also use the
     [`eventheader-register`](libeventheader-tracepoint/tools/eventheader-register.cpp)
     tool to pre-register an event based on its tracepoint name so you can start
-    collecting it before starting the program that generates it.
+    collecting it before starting the program that generates it. If writing
+    your own event collection tool that collects eventheader-enabled events,
+    you might do something similar in your own tool to pre-register the events
+    that you need to collect.
 - Use the [`decode-perf`](libeventheader-decode-cpp/tools/decode-perf.cpp)
-  tool to decode the `perf.data` file to JSON text.
+  tool to decode the `perf.data` file to JSON text, or write your own decoding
+  tool using [libtracepoint-decode-cpp](libtracepoint-decode-cpp) and
+  [libeventheader-decode-cpp](libeventheader-decode-cpp).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ events and for generating Tracepoint events from user mode using the
   - Rust programs can use the [eventheader](rust/eventheader/README.md) or
     [eventheader_dynamic](rust/eventheader_dynamic/README.md) crates
     to generate eventheader-enabled Tracepoint events.
-- To collect events in a C++ program, use the
+- To collect events in a C++ program, use
   [libtracepoint-control-cpp](libtracepoint-control-cpp). Note that your
   program must run as a privileged user because access to the event collection
   system is restricted by default.
@@ -124,7 +124,7 @@ events and for generating Tracepoint events from user mode using the
 - Use the [`decode-perf`](libeventheader-decode-cpp/tools/decode-perf.cpp)
   tool to decode the `perf.data` file to JSON text, or write your own decoding
   tool using [libtracepoint-decode-cpp](libtracepoint-decode-cpp) and
-  [libeventheader-decode-cpp](libeventheader-decode-cpp).
+  `libeventheader-decode-cpp`.
 
 ## Contributing
 

--- a/libeventheader-decode-cpp/README.md
+++ b/libeventheader-decode-cpp/README.md
@@ -5,7 +5,7 @@ C++ library for decoding events that use the eventheader envelope.
 - **[EventEnumerator.h](include/eventheader/EventEnumerator.h):**
   Splits an eventheader-encoded event into fields.
 - **[EventFormatter.h](include/eventheader/EventFormatter.h):**
-  Turns event fields into strings.
+  Turns events or fields into strings.
 - **[decode-perf](samples/decode-perf.cpp):**
   Simple tool that uses `EventFormatter` and `PerfDataFile` to decode a
   `perf.data` file into JSON text. Works on Linux or Windows.

--- a/libtracepoint-control-cpp/README.md
+++ b/libtracepoint-control-cpp/README.md
@@ -1,9 +1,9 @@
 #  libtracepoint-control-cpp
 
-- `TracingPath.h` has functions for finding the `/sys/kernel/tracing` mount
-  point and reading `format` files.
-- `TracingCache.h` implements a cache for tracking parsed `format` files based
-  on system+name or by `common_type` id.
-- `TracingSession.h` implements session control (add/remove tracepoints from a
-  session) and data collection (enumerate the events that the session has
-  collected).
+- `TracingSession.h` implements an event collection session that can
+  collect tracepoint events and enumerate the events that the session has
+  collected.
+- `TracingPath.h` has functions for finding the `/sys/kernel/tracing`
+  mount point and reading `format` files.
+- `TracingCache.h` implements a cache for tracking parsed `format` files
+  based on system+name or by `common_type` id.

--- a/libtracepoint-control-cpp/README.md
+++ b/libtracepoint-control-cpp/README.md
@@ -6,4 +6,4 @@
 - `TracingPath.h` has functions for finding the `/sys/kernel/tracing`
   mount point and reading `format` files.
 - `TracingCache.h` implements a cache for tracking parsed `format` files
-  based on system+name or by `common_type` id.
+  and locating cached data by system+name or by `common_type` id.

--- a/libtracepoint/README.md
+++ b/libtracepoint/README.md
@@ -4,6 +4,8 @@
 [default implementation](src/tracepoint.c)
 writes data to the Linux
 [user_events](https://docs.kernel.org/trace/user_events.html) facility.
+The implementation of this interface can be replaced at link time to support
+alternative scenarios, e.g. testing with a mock tracing implementation.
 
 - [samples/tracepoint-sample.c](samples/tracepoint-sample.c) -
   demonstrates basic usage of the interface.
@@ -21,7 +23,8 @@ writes data to the Linux
 to use a higher-level library implemented on top of this interface, such as
 `tracepoint-provider.h`.
 
-Alternative implementations of this interface are expected. A developer would
+Alternative implementations of this interface are expected, e.g. a mock
+tracing implementation could be used for testing. A developer would
 select the alternative implementation by linking against a different
 library.
 


### PR DESCRIPTION
Overview:

- Update READMEs.
- Clean up comments in TracepointSession.h.
- Rename `m_enumSort` to `m_enumeratorBookmarks`.
- Minor tweaks in TracepointSession.cpp.

TracepointSession.cpp details:

- `NonSampleFnReturnFalse`: Take eventHeader by value since it is 8 bytes so that the compiler can do better alias analysis.
- Move TracepointSession destructor up above the constructor for consistency with the ordering in the header.
- Rename `m_enumSort` to `m_enumeratorBookmarks`.
- Don't worry about overflow of `m_lostEventCount`. (If the caller cares about this value, they're probably using this as a counter-since-last-time-I-checked, in which case overflow is what they want anyway.)
- Change the calculation of `beforeWrap`. This calculation seems more clear
  to me: it establishes a clear sequence of values `sampleDataBufferPos` ->
  `m_bufferSize` -> `unmaskedDataPosEnd`, with `beforeWrap` and `afterWrap` defined as the intervals between them. You can do algebra to see that the resulting value is identical to the old way.
- `pEnd = p + sampleDataSize`, so replace `pEnd - p` with `sampleDataSize`.
- In `MoveNext`, move a few operations out of the loop.