### PR TITLE
Set VERSION=1.1.0, add CommonFieldsSize() accessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
-project(LinuxTracepoints)
+project(LinuxTracepoints
+    VERSION 1.1.0)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-decode-cpp
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "EventHeader tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libeventheader-decode-cpp/src/EventFormatter.cpp
+++ b/libeventheader-decode-cpp/src/EventFormatter.cpp
@@ -1872,7 +1872,8 @@ EventFormatter::AppendSampleAsJson(
     char const* sampleEventName;
     size_t sampleProviderNameLength;
 
-    if (sampleEventInfo.raw_meta && sampleEventInfo.raw_meta->HasEventHeader())
+    if (sampleEventInfo.raw_meta &&
+        sampleEventInfo.raw_meta->Kind() == PerfEventKind::EventHeader)
     {
         // eventheader metadata.
 

--- a/libeventheader-decode-dotnet/CMakeLists.txt
+++ b/libeventheader-decode-dotnet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-decode-dotnet
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "EventHeader tracepoint decoding for .NET"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CSharp)

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-tracepoint
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libeventheader-tracepoint/include/CMakeLists.txt
+++ b/libeventheader-tracepoint/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-tracepoint-headers
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++ (headers)"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-control-cpp
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint-control-cpp/samples/control-lookup.cpp
+++ b/libtracepoint-control-cpp/samples/control-lookup.cpp
@@ -32,7 +32,7 @@ main(int argc, char* argv[])
             fprintf(stdout, "  Flds= %u\n", (unsigned)meta->Fields().size());
             fprintf(stdout, "  Id  = %u\n", (unsigned)meta->Id());
             fprintf(stdout, "  CmnC= %u\n", (unsigned)meta->CommonFieldCount());
-            fprintf(stdout, "  EH  = %u\n", (unsigned)meta->HasEventHeader());
+            fprintf(stdout, "  Kind= %u\n", (unsigned)meta->Kind());
             id = meta->Id();
         }
 

--- a/libtracepoint-decode-cpp/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-decode-cpp
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "Tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventMetadata.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventMetadata.h
@@ -155,6 +155,12 @@ namespace tracepoint_decode
             bool fileBigEndian) const noexcept;
     };
 
+    enum class PerfEventKind : uint8_t
+    {
+        Normal,         // No special handling detected.
+        EventHeader,    // First user field is named "eventheader_flags".
+    };
+
     class PerfEventMetadata
     {
         std::string_view m_systemName;
@@ -163,7 +169,8 @@ namespace tracepoint_decode
         std::vector<PerfFieldMetadata> m_fields;
         uint32_t m_id; // From common_type; not the same as the perf_event_attr::id or PerfSampleEventInfo::id.
         uint16_t m_commonFieldCount; // fields[common_field_count] is the first user field.
-        bool m_hasEventHeader; // true if first user field is named "eventheader_flags".
+        uint16_t m_commonFieldsSize; // Offset of the end of the last common field
+        PerfEventKind m_kind;
 
     public:
 
@@ -198,9 +205,14 @@ namespace tracepoint_decode
         constexpr uint16_t
         CommonFieldCount() const noexcept { return m_commonFieldCount; }
 
-        // Returns true if the first user field is named "eventheader_flags".
-        constexpr bool
-        HasEventHeader() const noexcept { return m_hasEventHeader; }
+        // Returns the offset of the end of the last "common_*" field.
+        // This is the start of the first user field.
+        constexpr uint16_t
+        CommonFieldsSize() const noexcept { return m_commonFieldsSize; }
+
+        // Returns the detected event decoding system - Normal or EventHeader.
+        constexpr PerfEventKind
+        Kind() const noexcept { return m_kind; }
 
         // Sets all properties of this object to {} values.
         void

--- a/libtracepoint-decode-cpp/src/PerfEventMetadata.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventMetadata.cpp
@@ -702,7 +702,8 @@ PerfEventMetadata::PerfEventMetadata() noexcept
     , m_fields()
     , m_id()
     , m_commonFieldCount()
-    , m_hasEventHeader()
+    , m_commonFieldsSize()
+    , m_kind()
 {
     return;
 }
@@ -716,7 +717,8 @@ PerfEventMetadata::Clear() noexcept
     m_fields = {};
     m_id = {};
     m_commonFieldCount = {};
-    m_hasEventHeader = {};
+    m_commonFieldsSize = {};
+    m_kind = {};
 }
 
 bool
@@ -869,8 +871,20 @@ PerfEventMetadata::Parse(
 
 Done:
 
-    m_hasEventHeader =
+    if (m_commonFieldCount == 0)
+    {
+        m_commonFieldsSize = 0;
+    }
+    else
+    {
+        auto const& lastCommonField = m_fields[m_commonFieldCount - 1];
+        m_commonFieldsSize = lastCommonField.Offset() + lastCommonField.Size();
+    }
+
+    m_kind =
         m_fields.size() > m_commonFieldCount &&
-        m_fields[m_commonFieldCount].Name() == "eventheader_flags"sv;
+        m_fields[m_commonFieldCount].Name() == "eventheader_flags"sv
+        ? PerfEventKind::EventHeader
+        : PerfEventKind::Normal;
     return !m_name.empty() && foundId;
 }

--- a/libtracepoint/CMakeLists.txt
+++ b/libtracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "Linux tracepoints interface for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint/include/CMakeLists.txt
+++ b/libtracepoint/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-headers
-    VERSION 1.0.0
+    VERSION 1.1.0
     DESCRIPTION "Linux tracepoints interface for C/C++ (headers)"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)


### PR DESCRIPTION
- Set all CMake projects to VERSION=1.1.0.
- Change EventMetadata field from "bool HasEventHeader" to "enum Kind".
- Add EventMetadata field "CommonFieldsSize".