### PR TITLE
Disabled tracepoint is now EBADF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# LinuxTracepoints Change Log
+
+## v1.2 (TBD)
+
+- Kernel change means the "no sessions listening" case is now considered an
+  error (`EBADF`). Update the comments/documentation and the early-out cases
+  to match the kernel's new behavior.
+
+## v1.1 (2023-06-20)
+
+- Add namespaces to the C++ APIs.
+- Move non-eventheader logic from eventheader-decode to new tracepoint-decode
+  library.
+- Add new libtracepoint-control library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(LinuxTracepoints
-    VERSION 1.1.0)
+    VERSION 1.2.0)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-decode-cpp
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "EventHeader tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)
@@ -10,11 +10,11 @@ set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 set(BUILD_TOOLS ON CACHE BOOL "Build tool code")
 
 if(NOT TARGET tracepoint-decode)
-    find_package(tracepoint-decode 1.1 REQUIRED)
+    find_package(tracepoint-decode 1.2 REQUIRED)
 endif()
 
 if(NOT TARGET eventheader-headers)
-    find_package(eventheader-headers 1.1 REQUIRED)
+    find_package(eventheader-headers 1.2 REQUIRED)
 endif()
 
 if(WIN32)

--- a/libeventheader-decode-dotnet/CMakeLists.txt
+++ b/libeventheader-decode-dotnet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-decode-dotnet
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "EventHeader tracepoint decoding for .NET"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CSharp)

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-tracepoint
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)
@@ -30,11 +30,11 @@ add_subdirectory(include)
 if(NOT WIN32)
 
     if(NOT TARGET tracepoint-headers)
-        find_package(tracepoint-headers 1.1 REQUIRED)
+        find_package(tracepoint-headers 1.2 REQUIRED)
     endif()
 
     if(NOT TARGET tracepoint)
-        find_package(tracepoint 1.1 REQUIRED)
+        find_package(tracepoint 1.2 REQUIRED)
     endif()
 
     add_subdirectory(src)

--- a/libeventheader-tracepoint/include/CMakeLists.txt
+++ b/libeventheader-tracepoint/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-tracepoint-headers
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++ (headers)"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
+++ b/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
@@ -761,9 +761,9 @@ namespace ehd
 
         Returns 0 for success. Returns a nonzero errno value for failure. The return
         value is for diagnostic/debugging purposes only and should generally be ignored
-        in retail builds. Returns ENOMEM (12) if out of memory. Returns ERANGE (34) if the
-        event (headers + metadata + data) is greater than 64KB. Returns other errors as
-        reported by writev.
+        in retail builds. Returns EBADF (9) if tracepoint is unregistered or disabled.
+        Returns ENOMEM (12) if out of memory. Returns ERANGE (34) if the event (headers +
+        metadata + data) is greater than 64KB. Returns other errors as reported by writev.
         */
         int
         Write(

--- a/libeventheader-tracepoint/include/eventheader/TraceLoggingProvider.h
+++ b/libeventheader-tracepoint/include/eventheader/TraceLoggingProvider.h
@@ -2134,7 +2134,7 @@ _tlgApplyArgsN(macro, n, (handler, ...)) --> macro##handler(n, ...)
     static eventheader_tracepoint const* const _tlgEvtPtr \
         __attribute__((section("_tlgEventPtrs_" _tlg_STRINGIZE(providerSymbol)), used)) \
         = &_tlgEvt; \
-    int _tlgWriteErr = 0; \
+    int _tlgWriteErr = 9 /*EBADF*/; \
     if (TRACEPOINT_ENABLED(&_tlgEvtState)) { \
         struct iovec _tlgVecs[EVENTHEADER_PREFIX_DATAVEC_COUNT _tlg_FOREACH(_tlgDataDescCount, __VA_ARGS__)]; \
         unsigned _tlgIdx = EVENTHEADER_PREFIX_DATAVEC_COUNT; \

--- a/libeventheader-tracepoint/include/eventheader/eventheader-tracepoint.h
+++ b/libeventheader-tracepoint/include/eventheader/eventheader-tracepoint.h
@@ -142,8 +142,9 @@ extern "C" {
     /*
     Writes an event. Safe no-op if event is disabled.
 
-    - Returns 0 for success, errno for error. Result is primarily for
-      debugging/diagnostics and is usually ignored for production code.
+    - Returns 0 for success, EBADF if event is disabled, errno for error.
+      Result is primarily for debugging/diagnostics and is usually ignored
+      for production code.
     - If pActivityId is not NULL, event will have an activity_id extension.
     - If pEvent->metadata is not NULL, event will have a extension with the
       data from pEvent->metadata.

--- a/libeventheader-tracepoint/samples/dynamic-sample.cpp
+++ b/libeventheader-tracepoint/samples/dynamic-sample.cpp
@@ -1,8 +1,6 @@
 #include <eventheader/EventHeaderDynamic.h>
 #include <stdio.h>
 
-static_assert(EBADF == 9, "EBADF != 9");
-
 static char const guid1[16] = "123456789abcdef";
 static char const* const CharStrings[2] = {
     "abc", "123"
@@ -168,3 +166,6 @@ int main()
 
     return 0;
 }
+
+#include <errno.h>
+static_assert(EBADF == 9, "EBADF != 9");

--- a/libeventheader-tracepoint/samples/dynamic-sample.cpp
+++ b/libeventheader-tracepoint/samples/dynamic-sample.cpp
@@ -1,6 +1,8 @@
 #include <eventheader/EventHeaderDynamic.h>
 #include <stdio.h>
 
+static_assert(EBADF == 9, "EBADF != 9");
+
 static char const guid1[16] = "123456789abcdef";
 static char const* const CharStrings[2] = {
     "abc", "123"

--- a/libeventheader-tracepoint/samples/tracepoint-file.cpp
+++ b/libeventheader-tracepoint/samples/tracepoint-file.cpp
@@ -202,7 +202,7 @@ tracepoint_write(
 
     if (!TRACEPOINT_ENABLED(eventState))
     {
-        return 0;
+        return EBADF;
     }
 
     size_t size = 0;
@@ -218,7 +218,7 @@ tracepoint_write(
     auto const providerState = __atomic_load_n(&eventState->provider_state, __ATOMIC_RELAXED);
     if (providerState == NULL)
     {
-        return 0;
+        return EBADF;
     }
 
     auto lock = std::shared_lock(s_eventsMutex);

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-control-cpp
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)
@@ -11,7 +11,7 @@ set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 if(NOT WIN32)
 
     if(NOT TARGET tracepoint-decode)
-        find_package(tracepoint-decode 1.1 REQUIRED)
+        find_package(tracepoint-decode 1.2 REQUIRED)
     endif()
 
     add_compile_options(

--- a/libtracepoint-decode-cpp/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-decode-cpp
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "Tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint/CMakeLists.txt
+++ b/libtracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "Linux tracepoints interface for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint/include/CMakeLists.txt
+++ b/libtracepoint/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-headers
-    VERSION 1.1.0
+    VERSION 1.2.0
     DESCRIPTION "Linux tracepoints interface for C/C++ (headers)"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint/include/tracepoint/tracepoint-provider.h
+++ b/libtracepoint/include/tracepoint/tracepoint-provider.h
@@ -252,8 +252,8 @@ Supports up to 99 field parameters (subject to compiler and tracepoint system
 limitations). Each field parameter must be a field macro such as TPP_UINT8,
 TPP_STRING, etc.
 
-Returns 0 if the tracepoint is unregistered or disabled, 0 if the tracepoint
-is successfully emitted, errno otherwise. Result is primarily for
+Returns 0 if the tracepoint is written, EBADF if the tracepoint is unregistered
+or disabled, or other errno for an error. Result is primarily for
 debugging/diagnostics and is usually ignored for production code.
 */
 #define TPP_WRITE(ProviderSymbol, TracepointNameString, ...) \
@@ -299,8 +299,8 @@ limitations). Each field parameter must be a field macro such as TPP_UINT8,
 TPP_STRING, etc.
 
 The generated func_name(field values...) function returns 0 if the tracepoint
-is unregistered or disabled, 0 if the tracepoint is successfully emitted,
-errno otherwise. Result is primarily for debugging/diagnostics and is usually
+is written, EBADF if the tracepoint is unregistered or disabled, or other errno
+for an error. Result is primarily for debugging/diagnostics and is usually
 ignored for production code.
 */
 #define TPP_FUNCTION(ProviderSymbol, TracepointNameString, FunctionName, ...) \
@@ -805,7 +805,7 @@ _tppApplyArgsN(macro, n, (handler, ...)) --> macro##handler(n, ...)
     static tracepoint_definition const* _tppEvtPtr \
         __attribute__((section("_tppEventPtrs_" _tpp_STRINGIZE(ProviderSymbol)), used)) \
         = &_tppEvt; \
-    int _tppWriteErr = 0; \
+    int _tppWriteErr = 9 /*EBADF*/; \
     if (TRACEPOINT_ENABLED(&TracepointState)) { \
         struct iovec _tppVecs[1 _tpp_FOREACH(_tppDataDescCount, __VA_ARGS__)]; \
         _tppVecs[0].iov_len = 0; \

--- a/libtracepoint/include/tracepoint/tracepoint.h
+++ b/libtracepoint/include/tracepoint/tracepoint.h
@@ -117,10 +117,17 @@ extern "C" {
         char const* tp_name_args);
 
     /*
-    Writes the specified tracepoint. Returns 0 for success or if nobody is
-    listening, errno for failure. Calling tracepoint_write on a disconnected
-    tracepoint is a safe no-op. Calling tracepoint_write on a tracepoint that
-    is connected to a closed provider is a safe no-op.
+    Writes the specified tracepoint.
+
+    Returns:
+    - 0 for success.
+    - EBADF if the tracepoint is disconnected or if nobody is listening for
+      this tracepoint.
+    - Other errno value for failure.
+
+    Calling tracepoint_write on a disconnected tracepoint is a safe no-op.
+    Calling tracepoint_write on a tracepoint that is connected to a closed
+    provider is a safe no-op.
 
     For optimal performance, only call this function if
     TRACEPOINT_ENABLED(tp_state) returns non-zero.

--- a/libtracepoint/samples/tracepoint-sample.c
+++ b/libtracepoint/samples/tracepoint-sample.c
@@ -28,7 +28,7 @@ int main()
     err = TRACEPOINT_ENABLED(&unopened_tracepoint);
     printf("TRACEPOINT_ENABLED with unopened tracepoint: %d\n", err); // Expect 0.
     err = tracepoint_write(&unopened_tracepoint, 1, &(struct iovec){}); // No-op.
-    printf("tracepoint_write with unopened tracepoint: %d\n", err); // Expect 0.
+    printf("tracepoint_write with unopened tracepoint: %d\n", err); // Expect EBADF.
 
     // The provider is inert before it is opened.
     tracepoint_close_provider(&provider); // No-op.

--- a/libtracepoint/src/tracepoint.c
+++ b/libtracepoint/src/tracepoint.c
@@ -449,13 +449,13 @@ extern "C" {
 
         if (!TRACEPOINT_ENABLED(tp_state))
         {
-            return 0;
+            return EBADF;
         }
 
         tracepoint_provider_state const* provider_state = __atomic_load_n(&tp_state->provider_state, __ATOMIC_RELAXED);
         if (provider_state == NULL)
         {
-            return 0;
+            return EBADF;
         }
 
         // Workaround: Events don't show up correctly with 0 bytes of data.

--- a/libtracepoint/utest/tpp-utest-cpp.cpp
+++ b/libtracepoint/utest/tpp-utest-cpp.cpp
@@ -3,8 +3,6 @@
 
 #include <stdio.h>
 
-static_assert(EBADF == 9, "EBADF != 9");
-
 int TestCpp(void)
 {
     int err = TPP_REGISTER_PROVIDER(TestProvider);
@@ -15,3 +13,6 @@ int TestCpp(void)
     TPP_UNREGISTER_PROVIDER(TestProvider);
     return ok != 0 && err == 0;
 }
+
+#include <errno.h>
+static_assert(EBADF == 9, "EBADF != 9");

--- a/libtracepoint/utest/tpp-utest-cpp.cpp
+++ b/libtracepoint/utest/tpp-utest-cpp.cpp
@@ -3,6 +3,8 @@
 
 #include <stdio.h>
 
+static_assert(EBADF == 9, "EBADF != 9");
+
 int TestCpp(void)
 {
     int err = TPP_REGISTER_PROVIDER(TestProvider);

--- a/libtracepoint/utest/tracepoint-utest.cpp
+++ b/libtracepoint/utest/tracepoint-utest.cpp
@@ -55,7 +55,7 @@ static void
 verify_tp_disconnected(unsigned line, tracepoint_state const& e)
 {
     iovec emptyVec = {};
-    CHECK(tracepoint_write(&e, 1, &emptyVec));
+    tracepoint_write(&e, 1, &emptyVec);
 
     verify_cond(line, 0 == e.status_word,
         "Disconnected event status_word: expected 0, actual %u", e.status_word);
@@ -73,7 +73,7 @@ static void
 verify_tp_closed(unsigned line, tracepoint_state const& e, tracepoint_provider_state const& p)
 {
     iovec emptyVec = {};
-    CHECK(tracepoint_write(&e, 1, &emptyVec));
+    tracepoint_write(&e, 1, &emptyVec);
 
     verify_cond(line, &p == e.provider_state,
         "Closed event provider_state: expected %p, actual %p", &p, e.provider_state);
@@ -86,7 +86,7 @@ static void
 verify_tp_open(unsigned line, tracepoint_state const& e, tracepoint_provider_state const& p)
 {
     iovec emptyVec = {};
-    CHECK(tracepoint_write(&e, 1, &emptyVec));
+    tracepoint_write(&e, 1, &emptyVec);
 
     verify_cond(line, &p == e.provider_state,
         "Open event provider_state: expected %p, actual %p", &p, e.provider_state);


### PR DESCRIPTION
Linux Kernel is changing to report an EBADF error if you try to write to a tracepoint that has no listeners. Update the tracepoint library to have behavior consistent with this:

- Update comments/documentation to indicate that the caller should expect EBADF if the tracepoint is not enabled.
- In cases where we skip the writev because we know the tracepoint is disabled, we now need to return EBADF instead of 0.
- In the interceptor sample, return EBADF for disabled.
- Update version number to 1.2.