### PR TITLE
libtracepoint-control - add Preregister methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # LinuxTracepoints Change Log
 
-## v1.2 (TBD)
+## v1.2 (2023-06-27)
 
-- Kernel change means the "no sessions listening" case is now considered an
-  error (`EBADF`). Update the comments/documentation and the early-out cases
-  to match the kernel's new behavior.
+- Added "Preregister" methods to the `TracepointCache` class so that a
+  controller can pre-register events that it wants to collect.
+- If no consumers have enabled a tracepoint, the kernel now returns `EBADF`.
+  The provider APIs have been updated to be consistent with the new behavior.
 
 ## v1.1 (2023-06-20)
 

--- a/libtracepoint-control-cpp/include/tracepoint/TracepointPath.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointPath.h
@@ -42,6 +42,20 @@ namespace tracepoint_control
     GetTracingDirectory() noexcept;
 
     /*
+    Returns a file descriptor for the user_events_data file. Result will be
+    non-negative on success or negative (-errno) on error.
+
+    Do not close the returned descriptor. Use it only for ioctl and writev.
+
+    Implementation: The first time this is called, it calls GetTracingDirectory()
+    to find the tracefs or debugfs mount point, then opens
+    "TracingDirectory/user_events_data" and caches the result. Subsequent calls
+    return the cached result. This function is thread-safe.
+    */
+    _Success_(return >= 0) int
+    GetUserEventsDataFile() noexcept;
+
+    /*
     Given full path to a file, appends the file's contents to the specified
     dest string.
 

--- a/libtracepoint-control-cpp/src/TracepointCache.cpp
+++ b/libtracepoint-control-cpp/src/TracepointCache.cpp
@@ -6,6 +6,71 @@
 #include <assert.h>
 #include <errno.h>
 #include <string.h>
+#include <stdio.h>
+
+#include <linux/types.h>
+#include <sys/ioctl.h>
+
+//#include <linux/user_events.h>
+struct user_reg63 {
+
+    /* Input: Size of the user_reg structure being used */
+    __u32 size;
+
+    /* Input: Bit in enable address to use */
+    __u8 enable_bit;
+
+    /* Input: Enable size in bytes at address */
+    __u8 enable_size;
+
+    /* Input: Flags for future use, set to 0 */
+    __u16 flags;
+
+    /* Input: Address to update when enabled */
+    __u64 enable_addr;
+
+    /* Input: Pointer to string with event name, description and flags */
+    __u64 name_args;
+
+    /* Output: Index of the event to use when writing data */
+    __u32 write_index;
+} __attribute__((__packed__));
+
+/*
+ * Describes an event unregister, callers must set the size, address and bit.
+ * This structure is passed to the DIAG_IOCSUNREG ioctl to disable bit updates.
+ */
+struct user_unreg63 {
+    /* Input: Size of the user_unreg structure being used */
+    __u32 size;
+
+    /* Input: Bit to unregister */
+    __u8 disable_bit;
+
+    /* Input: Reserved, set to 0 */
+    __u8 __reserved;
+
+    /* Input: Reserved, set to 0 */
+    __u16 __reserved2;
+
+    /* Input: Address to unregister */
+    __u64 disable_addr;
+} __attribute__((__packed__));
+
+#define DIAG_IOC_MAGIC '*'
+#define DIAG_IOCSREG _IOWR(DIAG_IOC_MAGIC, 0, struct user_reg63*)
+#define DIAG_IOCSDEL _IOW(DIAG_IOC_MAGIC, 1, char*)
+#define DIAG_IOCSUNREG _IOW(DIAG_IOC_MAGIC, 2, struct user_unreg63*)
+
+//#include <eventheader.h>
+#define EVENTHEADER_COMMAND_TYPES "u8 eventheader_flags;u8 version;u16 id;u16 tag;u8 opcode;u8 level"
+enum {
+    // Maximum length of a Tracepoint name "ProviderName_Attributes", including nul termination.
+    EVENTHEADER_NAME_MAX = 256,
+
+    // Maximum length needed for a DIAG_IOCSREG command "ProviderName_Attributes CommandTypes".
+    EVENTHEADER_COMMAND_MAX = EVENTHEADER_NAME_MAX + sizeof(EVENTHEADER_COMMAND_TYPES)
+};
 
 using namespace std::string_view_literals;
 using namespace tracepoint_control;
@@ -14,6 +79,32 @@ using namespace tracepoint_decode;
 static constexpr int8_t CommonTypeOffsetInit = -1;
 static constexpr uint8_t CommonTypeSizeInit = 0;
 
+static bool
+IsLowercaseHex(char ch)
+{
+    return ('0' <= ch && ch <= '9') || ('a' <= ch && ch <= 'f');
+}
+
+TracepointCache::TracepointRegistration::~TracepointRegistration()
+{
+    if (WriteIndex >= 0)
+    {
+        user_unreg63 unreg = {};
+        unreg.size = sizeof(user_unreg63);
+        unreg.disable_bit = 0;
+        unreg.disable_addr = (uintptr_t)&StatusWord;
+        ioctl(DataFile, DIAG_IOCSUNREG, &unreg);
+    }
+}
+
+TracepointCache::TracepointRegistration::TracepointRegistration() noexcept
+    : DataFile(-1)
+    , WriteIndex(-1)
+    , StatusWord(0)
+{
+    return;
+}
+
 TracepointCache::CacheVal::~CacheVal()
 {
     return;
@@ -21,9 +112,11 @@ TracepointCache::CacheVal::~CacheVal()
 
 TracepointCache::CacheVal::CacheVal(
     std::vector<char>&& systemAndFormat,
-    PerfEventMetadata&& metadata) noexcept
+    PerfEventMetadata&& metadata,
+    std::unique_ptr<TracepointRegistration> registration) noexcept
     : SystemAndFormat(std::move(systemAndFormat))
     , Metadata(metadata)
+    , Registration(std::move(registration))
 {
     return;
 }
@@ -139,7 +232,7 @@ TracepointCache::AddFromFormat(
         systemAndFormat.assign(systemName.begin(), systemName.end());
         systemAndFormat.push_back('\n'); // For readability when debugging.
         systemAndFormat.insert(systemAndFormat.end(), formatFileContents.begin(), formatFileContents.end());
-        error = Add(std::move(systemAndFormat), systemName.size(), longSize64);
+        error = Add(std::move(systemAndFormat), systemName.size(), longSize64, nullptr);
     }
     catch (...)
     {
@@ -163,7 +256,7 @@ TracepointCache::AddFromSystem(TracepointName name) noexcept
         error = AppendTracingFormatFile(systemAndFormat, name.SystemName, name.EventName);
         if (error == 0)
         {
-            error = Add(std::move(systemAndFormat), name.SystemName.size(), sizeof(long) == 8);
+            error = Add(std::move(systemAndFormat), name.SystemName.size(), sizeof(long) == 8, nullptr);
         }
     }
     catch (...)
@@ -199,10 +292,149 @@ TracepointCache::FindOrAddFromSystem(
 }
 
 _Success_(return == 0) int
+TracepointCache::PreregisterEventHeaderTracepoint(std::string_view eventName) noexcept
+{
+    if (eventName.size() >= EVENTHEADER_NAME_MAX ||
+        eventName.size() <= 5 || // "_L1K1"
+        eventName.find(' ') != eventName.npos ||
+        eventName.find(':') != eventName.npos)
+    {
+        // Too long, or too short, or contains space, or contains colon.
+        return EINVAL;
+    }
+
+    auto i = eventName.rfind('_');
+    if (i > eventName.size() - 5 ||
+        eventName[i + 1] != 'L' ||
+        !IsLowercaseHex(eventName[i + 2]))
+    {
+        // Does not end with "_Ln...".
+        return EINVAL;
+    }
+
+    i += 3; // Skip "_Ln".
+    while (i != eventName.size() && IsLowercaseHex(eventName[i]))
+    {
+        // Skip additional digits of level.
+        i += 1;
+    }
+
+    if (i >= eventName.size() - 1 ||
+        eventName[i] != 'K' ||
+        !IsLowercaseHex(eventName[i + 1]))
+    {
+        // Does not end with "_LnKn..."
+        return EINVAL;
+    }
+
+    i += 2; // Skip "Kn"
+
+    // Skip additional digits of Keyword and additional attributes.
+    for (; i != eventName.size(); i += 1)
+    {
+        auto const ch = eventName[i];
+        if ((ch < '0' || '9' < ch) &&
+            (ch < 'A' || 'Z' < ch) &&
+            (ch < 'a' || 'z' < ch))
+        {
+            // Invalid attribute character.
+            return EINVAL;
+        }
+    }
+
+    char nameArgs[EVENTHEADER_COMMAND_MAX];
+    snprintf(nameArgs, sizeof(nameArgs), "%.*s " EVENTHEADER_COMMAND_TYPES,
+        (unsigned)eventName.size(), eventName.data());
+    return PreregisterTracepoint(nameArgs);
+}
+
+_Success_(return == 0) int
+TracepointCache::PreregisterTracepoint(_In_z_ char const* registerCommand) noexcept
+{
+    int error;
+
+    size_t nameEnd;
+    for (nameEnd = 0;; nameEnd += 1)
+    {
+        auto ch = registerCommand[nameEnd];
+        if (ch == 0 || ch == ' ' || ch == ':')
+        {
+            break;
+        }
+    }
+
+    TracepointName name("user_events"sv, std::string_view(registerCommand, nameEnd));
+
+    if (nameEnd == 0 || nameEnd >= EVENTHEADER_NAME_MAX)
+    {
+        error = EINVAL;
+        goto Done;
+    }
+
+    if (m_byName.find(name) != m_byName.end())
+    {
+        error = EALREADY;
+        goto Done;
+    }
+
+    try
+    {
+        auto registration = std::make_unique<TracepointRegistration>();
+
+        auto const dataFile = GetUserEventsDataFile();
+        if (dataFile < 0)
+        {
+            error = -dataFile;
+            goto Done;
+        }
+
+        user_reg63 reg = {};
+        reg.size = sizeof(reg);
+        reg.enable_bit = 0;
+        reg.enable_size = sizeof(registration->StatusWord);
+        reg.enable_addr = (uintptr_t)&registration->StatusWord;
+        reg.name_args = (uintptr_t)registerCommand;
+
+        if (0 > ioctl(registration->DataFile, DIAG_IOCSREG, &reg))
+        {
+            error = errno;
+            goto Done;
+        }
+
+        assert(reg.write_index <= 0x7fffffff);
+        registration->DataFile = dataFile;
+        registration->WriteIndex = static_cast<int>(reg.write_index);
+
+        std::vector<char> systemAndFormat;
+        systemAndFormat.reserve(name.SystemName.size() + 512); // may throw
+        systemAndFormat.assign(name.SystemName.begin(), name.SystemName.end());
+        systemAndFormat.push_back('\n'); // For readability when debugging.
+        error = AppendTracingFormatFile(systemAndFormat, name.SystemName, name.EventName);
+        if (error == 0)
+        {
+            error = Add(
+                std::move(systemAndFormat),
+                name.SystemName.size(),
+                sizeof(long) == 8,
+                std::move(registration));
+        }
+    }
+    catch (...)
+    {
+        error = ENOMEM;
+    }
+
+Done:
+
+    return error;
+}
+
+_Success_(return == 0) int
 TracepointCache::Add(
     std::vector<char>&& systemAndFormat,
     size_t systemNameSize,
-    bool longSize64) noexcept
+    bool longSize64,
+    std::unique_ptr<TracepointRegistration> registration) noexcept
 {
     int error;
     uint32_t id = 0;
@@ -271,7 +503,11 @@ TracepointCache::Add(
             {
                 id = metadata.Id();
 
-                auto er = m_byId.try_emplace(id, std::move(systemAndFormat), std::move(metadata));
+                auto er = m_byId.try_emplace(
+                    id,
+                    std::move(systemAndFormat),
+                    std::move(metadata),
+                    std::move(registration));
                 assert(er.second);
                 idAdded = er.second;
 


### PR DESCRIPTION
Kernel changed so that tracepoint registrations will not persist after they are closed, which means any pre-registration needs to be kept open rather than being a one-shot operation. Best fix seems to be to add pre-registration support to the TracepointCache class so that pre-registration lifetime is tied to the cache.

TracepointPath:
- Add code for accessing the user_events_data file. This duplicates some code from libtracepoint, but it's slightly different and I don't want to make the libtracepoint version public, so duplication seems ok to me.

TracepointCache:
- Add `PreregisterTracepoint` method that accepts a generic user_events tracepoint registration string (event name + field definitions). It registers the tracepoint and stores the registration in the cache so that the tracepoint remains registered as long as the cache is alive.
- Add `PreregisterEventHeaderTracepoint` method that accepts an EventHeader event name. It validates the event name, creates a tracepoint registration string, and calls `PreregisterTracepoint`.