### PR TITLE
TracepointCache - use TracepointName for preregister

### DIFF
--- a/libtracepoint-control-cpp/include/tracepoint/TracepointCache.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointCache.h
@@ -75,7 +75,7 @@ namespace tracepoint_control
         Otherwise, return NULL.
         */
         tracepoint_decode::PerfEventMetadata const*
-        FindByName(TracepointName name) const noexcept;
+        FindByName(TracepointName const& name) const noexcept;
 
         /*
         If metadata for an event with the specified data is cached,
@@ -92,7 +92,8 @@ namespace tracepoint_control
         FindByRawData(std::string_view rawData) const noexcept;
 
         /*
-        Parse the formatFileContents to get the metadata. If metadata for an
+        Parse the formatFileContents to get the metadata. If systemName or
+        formatFileContents is invalid, return EINVAL. If metadata for an
         event with the same name or ID is already cached, return EEXIST.
         Otherwise, add the metadata to the cache.
         */
@@ -103,12 +104,13 @@ namespace tracepoint_control
             bool longSize64 = sizeof(long) == 8) noexcept;
 
         /*
-        Load and parse the "/sys/.../tracing/events/systemName/eventName/format" file.
-        If metadata for an event with the same name or ID is cached, return EEXIST.
+        Load and parse the "/sys/.../tracing/events/systemName/eventName/format"
+        file. If name or the format data is invalid, return EINVAL. If metadata
+        for an event with the same name or ID is already cached, return EEXIST.
         Otherwise, add the metadata to the cache.
         */
         _Success_(return == 0) int
-        AddFromSystem(TracepointName name) noexcept;
+        AddFromSystem(TracepointName const& name) noexcept;
 
         /*
         If metadata for an event with the specified name is cached, return it.
@@ -116,20 +118,20 @@ namespace tracepoint_control
         */
         _Success_(return == 0) int
         FindOrAddFromSystem(
-            TracepointName name,
+            TracepointName const& name,
             _Out_ tracepoint_decode::PerfEventMetadata const** ppMetadata) noexcept;
 
         /*
-        Given the eventName for a user_events EventHeader tracepoint, pre-register and
+        Given the name of a user_events EventHeader tracepoint, pre-register and
         cache the specified event.
 
-        Example eventName: "MyProvider_L1Kff"
+        Example eventName: "user_events:MyProvider_L1Kff"
 
         Details:
 
-        - If the specified eventName is not a valid EventHeader event name, return EINVAL.
+        - If the specified name is not a valid user_events EventHeader name, return EINVAL.
         - If metadata for "user_events:eventName" is already cached, return EEXIST.
-        - Try to register a tracepoint using the standard EventHeader command string. If
+        - Try to register an EventHeader tracepoint with the given tracepoint name. If
           this fails, return the error.
         - Return AddFromSystem("user_events:eventName").
 
@@ -137,7 +139,7 @@ namespace tracepoint_control
         object exists.
         */
         _Success_(return == 0) int
-        PreregisterEventHeaderTracepoint(std::string_view eventName) noexcept;
+        PreregisterEventHeaderTracepoint(TracepointName const& name) noexcept;
 
         /*
         Given the registration command for a user_events tracepoint, pre-register and
@@ -147,7 +149,7 @@ namespace tracepoint_control
 
         Details:
 
-        - Parse the command to determine the eventName. If unable to parse, return EINVAL.
+        - Parse the command to determine the eventName. If invalid, return EINVAL.
         - If metadata for "user_events:eventName" is already cached, return EEXIST.
         - Try to register a user_events tracepoint using the specified command string. If
           this fails, return the error.

--- a/libtracepoint-control-cpp/include/tracepoint/TracepointName.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointName.h
@@ -14,6 +14,146 @@ TracepointName is a SystemName and EventName.
 namespace tracepoint_control
 {
     /*
+    The name of the "user_events" system.
+    */
+    static constexpr std::string_view UserEventsSystemName = std::string_view("user_events", 11);
+
+    /*
+    Returns true if the specified string is a valid tracepoint system name.
+
+    At present, this returns true if:
+    - systemName is not empty.
+    - systemName is less than 256 chars in length.
+    - systemName does not contain nul, space, slash, or colon.
+    */
+    constexpr bool
+    SystemNameIsValid(std::string_view systemName) noexcept
+    {
+        return systemName.size() > 0
+            && systemName.size() < 256
+            && systemName.find('\0') == std::string_view::npos
+            && systemName.find(' ') == std::string_view::npos
+            && systemName.find('/') == std::string_view::npos
+            && systemName.find(':') == std::string_view::npos;
+    }
+
+    /*
+    Returns true if the specified string is a valid tracepoint event name.
+
+    At present, this returns true if:
+    - eventName is not empty.
+    - eventName is less than 256 chars in length.
+    - eventName does not contain nul, space, slash, or colon.
+    */
+    constexpr bool
+    EventNameIsValid(std::string_view eventName) noexcept
+    {
+        return eventName.size() > 0
+            && eventName.size() < 256
+            && eventName.find('\0') == std::string_view::npos
+            && eventName.find(' ') == std::string_view::npos
+            && eventName.find('/') == std::string_view::npos
+            && eventName.find(':') == std::string_view::npos;
+    }
+
+    /*
+    Returns true if the specified string is a valid EventHeader tracepoint name,
+    e.g. "MyComponent_MyProvider_L1K2e" or "MyComponent_MyProv_L5K1Gmyprovider".
+
+    A valid EventHeader tracepoint name is a valid tracepoint event name that ends
+    with a "_LxKx..." suffix, where "x" is 1 or more lowercase hex digits and "..."
+    is 0 or more ASCII letters or digits.
+    */
+    static constexpr bool
+    EventHeaderEventNameIsValid(std::string_view eventName) noexcept
+    {
+        auto const eventNameSize = eventName.size();
+
+        if (eventNameSize < 5 || // 5 = "_L1K1".size()
+            !EventNameIsValid(eventName))
+        {
+            return false;
+        }
+
+        auto i = eventName.rfind('_');
+        if (i > eventNameSize - 5 || // 5 = "_L1K1".size()
+            eventName[i + 1] != 'L')
+        {
+            // Does not end with "_L...".
+            return false;
+        }
+
+        i += 2; // Skip "_L".
+
+        // Skip level value (lowercase hex digits).
+        auto const levelStart = i;
+        for (; i != eventNameSize; i += 1)
+        {
+            auto const ch = eventName[i];
+            if ((ch < '0' || '9' < ch) && (ch < 'a' || 'f' < ch))
+            {
+                break;
+            }
+        }
+
+        if (levelStart == i)
+        {
+            // Does not end with "_Lx...".
+            return false;
+        }
+
+        if (i == eventNameSize || eventName[i] != 'K')
+        {
+            // Does not end with "_LxK...".
+            return false;
+        }
+
+        i += 1; // Skip "K"
+
+        // Skip keyword value (lowercase hex digits).
+        auto const keywordStart = i;
+        for (; i != eventNameSize; i += 1)
+        {
+            auto const ch = eventName[i];
+            if ((ch < '0' || '9' < ch) && (ch < 'a' || 'f' < ch))
+            {
+                break;
+            }
+        }
+
+        if (keywordStart == i)
+        {
+            // Does not end with "_LxKx...".
+            return false;
+        }
+
+        // If there are attributes, validate them.
+        if (i != eventNameSize)
+        {
+            if (eventName[i] < 'A' || 'Z' < eventName[i])
+            {
+                // Invalid attribute lead char.
+                return false;
+            }
+
+            // Skip attributes and their values.
+            for (; i != eventNameSize; i += 1)
+            {
+                auto const ch = eventName[i];
+                if ((ch < '0' || '9' < ch) &&
+                    (ch < 'A' || 'Z' < ch) &&
+                    (ch < 'a' || 'z' < ch))
+                {
+                    // Invalid attribute character.
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /*
     A TracepointName is a string identifier for a tracepoint on a system.
     It contains two parts: SystemName and EventName.
 
@@ -68,7 +208,7 @@ namespace tracepoint_control
             auto const splitPos = systemAndEventName.find_first_of(":/", 0, 2);
             if (splitPos == systemAndEventName.npos)
             {
-                SystemName = std::string_view("user_events", 11);
+                SystemName = UserEventsSystemName;
                 EventName = systemAndEventName;
             }
             else
@@ -82,6 +222,26 @@ namespace tracepoint_control
         Require SystemName and EventName to always be specified.
         */
         TracepointName() = delete;
+
+        /*
+        Returns true if SystemName is a valid tracepoint system name and EventName
+        is a valid tracepoint event name.
+        */
+        constexpr bool
+        IsValid() const noexcept
+        {
+            return SystemNameIsValid(SystemName) && EventNameIsValid(EventName);
+        }
+
+        /*
+        Returns true if SystemName is a valid tracepoint system name and EventName
+        is a valid EventHeader tracepoint event name.
+        */
+        constexpr bool
+        IsValidEventHeader() const noexcept
+        {
+            return SystemNameIsValid(SystemName) && EventHeaderEventNameIsValid(EventName);
+        }
     };
 }
 // namespace tracepoint_control

--- a/libtracepoint-control-cpp/samples/control-session.cpp
+++ b/libtracepoint-control-cpp/samples/control-session.cpp
@@ -47,39 +47,33 @@ main(int argc, char* argv[])
     {
         TracepointName name(argv[argi]);
         error = cache.AddFromSystem(name);
-        if (error != ENOENT || name.SystemName != "user_events")
+        if (error != ENOENT || name.SystemName != UserEventsSystemName ||
+            !name.IsValidEventHeader())
         {
             fprintf(stderr, "AddFromSystem(%s) = %u\n", argv[argi], error);
         }
         else
         {
-            // User-specified event is not registered. If it's an EventHeader event, we can
-            // pre-register it and try to collect it anyway.
-            error = cache.PreregisterEventHeaderTracepoint(name.EventName);
+            // User-specified EventHeader event is not registered.
+            // Pre-register it and try to collect it anyway.
+            error = cache.PreregisterEventHeaderTracepoint(name);
             fprintf(stderr, "PreregisterEventHeaderTracepoint(%s) = %u\n", argv[argi], error);
         }
     }
 
+    fprintf(stderr, "\n");
+
+    unsigned enabled = 0;
     for (int argi = 2; argi < argc; argi += 1)
     {
         error = session.EnableTracePoint(TracepointName(argv[argi]));
         fprintf(stderr, "EnableTracePoint(%s) = %u\n", argv[argi], error);
+        enabled += error == 0;
     }
 
-    fprintf(stderr, "\n");
-
-    for (int argi = 2; argi < argc; argi += 1)
+    if (enabled == 0)
     {
-        error = session.DisableTracePoint(TracepointName(argv[argi]));
-        fprintf(stderr, "DisableTracePoint(%s) = %u\n", argv[argi], error);
-    }
-
-    fprintf(stderr, "\n");
-
-    for (int argi = 2; argi < argc; argi += 1)
-    {
-        error = session.EnableTracePoint(TracepointName(argv[argi]));
-        fprintf(stderr, "EnableTracePoint(%s) = %u\n", argv[argi], error);
+        return error;
     }
 
     for (;;)


### PR DESCRIPTION
- `PreregisterEventHeaderTracepoint` now takes a `TracepointName` instead of a `string_view` for the event name.
- TracepointCache now validates the incoming name strings.
- Tracepoint name string validation logic is moved to TracepointName.h and is exposed via public functions.