### PR TITLE
Prefer TraceFS over DebugFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # LinuxTracepoints Change Log
 
+## v1.2.1 (2023-07-24)
+
+- Prefer `user_events_data` from `tracefs` over `user_events_data` from
+  `debugfs`.
+
 ## v1.2 (2023-06-27)
 
 - Added "Preregister" methods to the `TracepointCache` class so that a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(LinuxTracepoints
-    VERSION 1.2.0)
+    VERSION 1.2.1)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-decode-cpp
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "EventHeader tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libeventheader-decode-dotnet/CMakeLists.txt
+++ b/libeventheader-decode-dotnet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-decode-dotnet
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "EventHeader tracepoint decoding for .NET"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CSharp)

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-tracepoint
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libeventheader-tracepoint/include/CMakeLists.txt
+++ b/libeventheader-tracepoint/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-tracepoint-headers
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++ (headers)"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-control-cpp
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint-control-cpp/src/TracepointPath.cpp
+++ b/libtracepoint-control-cpp/src/TracepointPath.cpp
@@ -117,7 +117,8 @@ UpdateTracingDirectory(char const** pStaticTracingDir) noexcept
                     pathSuffix = ""sv;
                     keepLooking = false; // prefer "tracefs" over "debugfs".
                 }
-                else if (fileSystem == "debugfs"sv)
+                else if (staticTracingDirBuffer[0] == 0 &&
+                    fileSystem == "debugfs"sv)
                 {
                     // "debugfsMountPoint/tracing"
                     pathSuffix = "/tracing"sv;

--- a/libtracepoint-decode-cpp/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-decode-cpp
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "Tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint/CMakeLists.txt
+++ b/libtracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "Linux tracepoints interface for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint/include/CMakeLists.txt
+++ b/libtracepoint/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-headers
-    VERSION 1.2.0
+    VERSION 1.2.1
     DESCRIPTION "Linux tracepoints interface for C/C++ (headers)"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint/src/tracepoint.c
+++ b/libtracepoint/src/tracepoint.c
@@ -203,7 +203,8 @@ user_events_data_update(int* staticFileOrError)
                 path_suffix_len = sizeof("/user_events_data"); // includes NUL
                 keepLooking = 0; // prefer "tracefs" over "debugfs".
             }
-            else if (fs_len == cchDebugfs && 0 == memcmp(line + fs_begin, pchDebugfs, cchDebugfs))
+            else if (path[0] == 0 &&
+                fs_len == cchDebugfs && 0 == memcmp(line + fs_begin, pchDebugfs, cchDebugfs))
             {
                 // "debugfsMountPoint/tracing/user_events_data"
                 path_suffix = "/tracing/user_events_data";


### PR DESCRIPTION
When looking for the tracing filesystem, we scan the mounted filesystems for either "tracefs" or "debugfs". We can use either one.

Old behavior is to take the first matching mount point, which might be either tracefs or debugfs. This can be confusing if the user has both debugfs and tracefs mounted - which one gets used? (Depends on which one comes first in the list of mounted filesystems.)

New behavior is to prefer tracefs over debugfs. That way, if both tracefs and debugfs are mounted, we consistently use tracefs, making the behavior more predictable.