### PR TITLE
Warnings/errors on arm32 build

### DIFF
--- a/libeventheader-decode-cpp/src/EventFormatter.cpp
+++ b/libeventheader-decode-cpp/src/EventFormatter.cpp
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
+#ifndef _TIME_BITS
+#define _TIME_BITS 64
+#endif
+
 #include <eventheader/EventFormatter.h>
 #include <tracepoint/PerfEventMetadata.h>
 #include <tracepoint/PerfEventInfo.h>

--- a/libtracepoint-control-cpp/samples/control-session.cpp
+++ b/libtracepoint-control-cpp/samples/control-session.cpp
@@ -17,7 +17,7 @@ using namespace tracepoint_decode;
 int
 main(int argc, char* argv[])
 {
-    int error;
+    int error = 0;
 
     if (argc < 2 ||
         (0 != strcmp(argv[1], "0") && 0 != strcmp(argv[1], "1")))
@@ -102,7 +102,7 @@ main(int argc, char* argv[])
                     event.cpu,
                     event.tid,
                     (long long unsigned)event.time,
-                    event.raw_data_size,
+                    (long unsigned)event.raw_data_size,
                     event.name);
                 return 0;
             });

--- a/libtracepoint-control-cpp/src/CMakeLists.txt
+++ b/libtracepoint-control-cpp/src/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(tracepoint-control
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(tracepoint-control
-    PUBLIC tracepoint-decode)
+    PUBLIC tracepoint-decode atomic)
 set(CONTROL_HEADERS
     "${PROJECT_SOURCE_DIR}/include/tracepoint/TracepointCache.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/TracepointName.h"


### PR DESCRIPTION
- time_t is 32-bit by default, which is a problem for our call to gmtime.
- warning for size mismatch in fprintf.
- warning for potentially unused variable.
- link error for missing `__atomic_store_8`, which can be an intrinsic or an extern depending on target.