### PR TITLE
Include clock information in event metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # LinuxTracepoints Change Log
 
+## v1.3.0 (TBD)
+
+- `PerfEventInfo.h` adds a field with session information to the metadata of
+  each event. The session information includes clock information.
+- `PerfDataFile.h` decodes clock information from perf.data files if present.
+- `TracepointSession.h` records clock information from the session.
+- `EventFormatter.h` formats timestamps as date-time if clock information is
+  available in the event metadata. If clock information is not present, it
+  continues to format timestamps as seconds.
+
 ## v1.2.1 (2023-07-24)
 
 - Prefer `user_events_data` from `tracefs` over `user_events_data` from

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ events and for generating Tracepoint events from user mode using the
   C++ library for controlling a tracepoint event collection session.
   - `TracingSession.h` implements an event collection session that can
     collect tracepoint events and enumerate the events that the session has
-    collected.
+    collected. Supports real-time and circular-buffer modes.
   - `TracingPath.h` has functions for finding the `/sys/kernel/tracing`
     mount point and reading `format` files.
   - `TracingCache.h` implements a cache for tracking parsed `format` files
@@ -88,8 +88,8 @@ events and for generating Tracepoint events from user mode using the
 - To collect events without writing C++ code, use the Linux
   [`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) tool
   to collect events to a `perf.data` file, e.g.
-  `perf record -e user_events:MyEvent1,user_events:MyEvent2`. Note that you
-  must run the `perf` tool as a privileged user to collect events.
+  `perf record -k monotonic -e user_events:MyEvent1,user_events:MyEvent2`. Note
+  that you must run the `perf` tool as a privileged user to collect events.
   - The `perf` tool binary is typically available as part of the `linux-perf`
     package (e.g. can be installed by `apt install linux-perf`). However, this
     package installs a `perf_VERSION` binary rather than a `perf` binary, so

--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-decode-cpp
-    VERSION 1.2.1
+    VERSION 1.3.0
     DESCRIPTION "EventHeader tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)
@@ -10,7 +10,7 @@ set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 set(BUILD_TOOLS ON CACHE BOOL "Build tool code")
 
 if(NOT TARGET tracepoint-decode)
-    find_package(tracepoint-decode 1.2 REQUIRED)
+    find_package(tracepoint-decode 1.3 REQUIRED)
 endif()
 
 if(NOT TARGET eventheader-headers)

--- a/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
+++ b/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
@@ -191,20 +191,18 @@ namespace eventheader_decode
     Flags controlling the metadata to be included in the "meta" suffix of a JSON
     event string.
 
-    Note that the "n" field is for the convenience if human readers of the JSON file.
-    It contains the provider and event metadata and appears at the start of the event
-    rather than in the metadata section even though it is technically metadata.
+    Note that the "n" field is for the convenience of human readers of the JSON file.
+    It contains the provider and event names and appears at the start of the event
+    rather than in the "meta" section even though it is technically metadata.
 
     Note that the format of the "time" field depends on the clock information that was
-    available from the session (use "perf record -k monotonic ..." to include
-    clock information into a perf trace):
+    provided by the session:
 
     - If clock information is available: "yyyy-mm-ddThh:mm:ss.nnnnnnnnnZ"
-    - Else, we output timestamp converted to seconds: 123.123456789
-      (Clock frequency may not be available, in which case we assume 1GHz.)
+    - Else, timestamp is seconds relative to an unknown epoch: 123.123456789
 
     For consistent behavior, always include clock information in the trace,
-    e.g. "perf record -k monotonic ...".
+    e.g. "perf record -k monotonic -e ...".
     */
     enum EventFormatterMetaFlags : unsigned
     {

--- a/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
+++ b/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
@@ -190,12 +190,27 @@ namespace eventheader_decode
     /*
     Flags controlling the metadata to be included in the "meta" suffix of a JSON
     event string.
+
+    Note that the "n" field is for the convenience if human readers of the JSON file.
+    It contains the provider and event metadata and appears at the start of the event
+    rather than in the metadata section even though it is technically metadata.
+
+    Note that the format of the "time" field depends on the clock information that was
+    available from the session (use "perf record -k monotonic ..." to include
+    clock information into a perf trace):
+
+    - If clock information is available: "yyyy-mm-ddThh:mm:ss.nnnnnnnnnZ"
+    - Else, we output timestamp converted to seconds: 123.123456789
+      (Clock frequency may not be available, in which case we assume 1GHz.)
+
+    For consistent behavior, always include clock information in the trace,
+    e.g. "perf record -k monotonic ...".
     */
     enum EventFormatterMetaFlags : unsigned
     {
         EventFormatterMetaFlags_None = 0,           // disable the "meta" suffix.
         EventFormatterMetaFlags_n = 0x1,            // "n":"provider:event" before the user fields (not in the suffix).
-        EventFormatterMetaFlags_time = 0x2,         // timestamp "seconds.nanoseconds" (only for sample events).
+        EventFormatterMetaFlags_time = 0x2,         // timestamp (only for sample events).
         EventFormatterMetaFlags_cpu = 0x4,          // cpu index (only for sample events).
         EventFormatterMetaFlags_pid = 0x8,          // process id (only for sample events).
         EventFormatterMetaFlags_tid = 0x10,         // thread id (only for sample events).

--- a/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
+++ b/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
@@ -55,7 +55,7 @@ Notes:
   event set will correspond to a tracepont named
   "user_events:MyCompany_MyComponent_L5K1f".
 - Collect events to a file using a tool such as "perf", e.g.
-  "perf record -e user_events:MyCompany_MyComponent_L5K1f".
+  "perf record -k monotonic -e user_events:MyCompany_MyComponent_L5K1f".
 - Decode events using a tool such as "decode-perf" (from the tools in the
   libeventheader-decode-cpp library).
 */

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-control-cpp
-    VERSION 1.2.1
+    VERSION 1.3.0
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)
@@ -11,7 +11,7 @@ set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 if(NOT WIN32)
 
     if(NOT TARGET tracepoint-decode)
-        find_package(tracepoint-decode 1.2 REQUIRED)
+        find_package(tracepoint-decode 1.3 REQUIRED)
     endif()
 
     add_compile_options(

--- a/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
@@ -12,6 +12,7 @@ TracepointSession class that manages a tracepoint collection session.
 #include "TracepointName.h"
 #include <tracepoint/PerfEventMetadata.h>
 #include <tracepoint/PerfEventInfo.h>
+#include <tracepoint/PerfEventSessionInfo.h>
 #include <tracepoint/TracepointCache.h>
 
 #include <unordered_map>
@@ -824,6 +825,7 @@ namespace tracepoint_control
         uint64_t m_lostEventCount;
         uint64_t m_corruptEventCount;
         uint64_t m_corruptBufferCount;
+        tracepoint_decode::PerfEventSessionInfo m_sessionInfo;
         tracepoint_decode::PerfSampleEventInfo m_enumEventInfo;
         char m_enumNameBuffer[512];
     };

--- a/libtracepoint-control-cpp/samples/control-session.cpp
+++ b/libtracepoint-control-cpp/samples/control-session.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #include <unistd.h>
 
@@ -98,10 +99,14 @@ main(int argc, char* argv[])
         error = session.EnumerateSampleEventsUnordered(
             [](PerfSampleEventInfo const& event) -> int
             {
-                fprintf(stdout, "CPU%u: tid=%x time=0x%llx raw=0x%lx n=%s\n",
+                auto ts = event.session->TimeToRealTime(event.time);
+                time_t const secs = (time_t)ts.tv_sec;
+                tm t = {};
+                gmtime_r(&secs, &t);
+                fprintf(stdout, "CPU%u: tid=%x time=%04u-%02u-%02uT%02u:%02u:%02u.%09uZ raw=0x%lx n=%s\n",
                     event.cpu,
                     event.tid,
-                    (long long unsigned)event.time,
+                    1900 + t.tm_year, 1 + t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, ts.tv_nsec,
                     (long unsigned)event.raw_data_size,
                     event.name);
                 return 0;

--- a/libtracepoint-control-cpp/src/TracepointSession.cpp
+++ b/libtracepoint-control-cpp/src/TracepointSession.cpp
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <string.h>
+#include <time.h>
 
 #include <unistd.h>
 #include <poll.h>
@@ -104,9 +105,36 @@ TracepointSession::TracepointSession(
     , m_lostEventCount(0)
     , m_corruptEventCount(0)
     , m_corruptBufferCount(0)
+    , m_sessionInfo()
     , m_enumEventInfo()
 {
+    static const auto Billion = 1000000000u;
+
     assert(options.m_mode <= TracepointSessionMode::RealTime);
+    m_sessionInfo.SetClockid(CLOCK_MONOTONIC_RAW);
+
+    timespec monotonic;
+    timespec realtime;
+    if (0 == clock_gettime(CLOCK_MONOTONIC_RAW, &monotonic) &&
+        0 == clock_gettime(CLOCK_REALTIME, &realtime))
+    {
+        uint64_t monotonicNS, realtimeNS;
+        if (monotonic.tv_sec < realtime.tv_sec)
+        {
+            monotonicNS = 0;
+            realtimeNS = static_cast<uint64_t>(realtime.tv_sec - monotonic.tv_sec) * Billion
+                + realtime.tv_nsec - monotonic.tv_nsec;
+        }
+        else
+        {
+            realtimeNS = 0;
+            monotonicNS = static_cast<uint64_t>(monotonic.tv_sec - realtime.tv_sec) * Billion
+                + monotonic.tv_nsec - realtime.tv_nsec;
+        }
+
+        m_sessionInfo.SetClockData(CLOCK_MONOTONIC_RAW, realtimeNS, monotonicNS);
+    }
+
     return;
 }
 
@@ -654,6 +682,7 @@ TracepointSession::ParseSample(
 
     enumEventInfo.id = infoId;
     enumEventInfo.attr = nullptr;
+    enumEventInfo.session = &m_sessionInfo;
     enumEventInfo.name = m_enumNameBuffer;
     enumEventInfo.sample_type = infoSampleTypes;
     enumEventInfo.raw_meta = infoRawMeta;
@@ -669,6 +698,7 @@ Error:
 
     enumEventInfo.id = {};
     enumEventInfo.attr = {};
+    enumEventInfo.session = {};
     enumEventInfo.name = {};
     enumEventInfo.sample_type = {};
     enumEventInfo.raw_meta = {};

--- a/libtracepoint-control-cpp/src/TracepointSession.cpp
+++ b/libtracepoint-control-cpp/src/TracepointSession.cpp
@@ -119,7 +119,8 @@ TracepointSession::TracepointSession(
         0 == clock_gettime(CLOCK_REALTIME, &realtime))
     {
         uint64_t monotonicNS, realtimeNS;
-        if (monotonic.tv_sec < realtime.tv_sec)
+        if (monotonic.tv_sec < realtime.tv_sec ||
+            (monotonic.tv_sec == realtime.tv_sec && monotonic.tv_nsec < realtime.tv_nsec))
         {
             monotonicNS = 0;
             realtimeNS = static_cast<uint64_t>(realtime.tv_sec - monotonic.tv_sec) * Billion

--- a/libtracepoint-decode-cpp/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-decode-cpp
-    VERSION 1.2.1
+    VERSION 1.3.0
     DESCRIPTION "Tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfDataFile.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfDataFile.h
@@ -6,6 +6,7 @@
 #define _included_PerfDataFile_h
 
 #include "PerfByteReader.h"
+#include "PerfEventSessionInfo.h"
 #include <stdint.h>
 #include <stdio.h> // FILE
 #include <map>
@@ -117,6 +118,7 @@ namespace tracepoint_decode
         std::vector<char> m_headers[32]; // Stored file-endian.
         std::vector<std::unique_ptr<perf_event_attr>> m_attrsList; // Stored host-endian.
         std::map<uint64_t, PerfEventDesc> m_eventDescById; // Points into m_attrsList and/or m_headers.
+        PerfEventSessionInfo m_sessionInfo;
         PerfByteReader m_byteReader;
         int8_t m_sampleIdOffset; // -1 = unset, -2 = no id.
         int8_t m_nonSampleIdOffset; // -1 = unset, -2 = no id.
@@ -255,6 +257,12 @@ namespace tracepoint_decode
 
         void
         ParseTracingData() noexcept;
+
+        void
+        ParseHeaderClockid() noexcept;
+
+        void
+        ParseHeaderClockData() noexcept;
 
         void
         ParseHeaderEventDesc() noexcept;

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
@@ -22,6 +22,9 @@ struct perf_event_attr;
 
 namespace tracepoint_decode
 {
+    // Forward declaration from PerfEventSessionInfo.h:
+    class PerfEventSessionInfo;
+
     // Forward declaration from PerfEventMetadata.h:
     class PerfEventMetadata;
 
@@ -29,6 +32,7 @@ namespace tracepoint_decode
     {
         uint64_t id;                            // Always valid if GetSampleEventInfo succeeded.
         perf_event_attr const* attr;            // Always valid if GetSampleEventInfo succeeded.
+        PerfEventSessionInfo const* session;    // Always valid if GetSampleEventInfo succeeded.
         _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
         uint64_t sample_type;                   // Bit set if corresponding info present in event.
         uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
@@ -42,13 +46,14 @@ namespace tracepoint_decode
         uint64_t const* callchain;              // Valid if sample_type & PERF_SAMPLE_CALLCHAIN. Points into event.
         PerfEventMetadata const* raw_meta;      // Valid if sample_type & PERF_SAMPLE_RAW. NULL if event unknown.
         _Field_size_bytes_(raw_data_size) void const* raw_data; // Valid if sample_type & PERF_SAMPLE_RAW. Points into event.
-        uintptr_t raw_data_size;                   // Valid if sample_type & PERF_SAMPLE_RAW. Size of raw_data.
+        uintptr_t raw_data_size;                // Valid if sample_type & PERF_SAMPLE_RAW. Size of raw_data.
     };
 
     struct PerfNonSampleEventInfo
     {
         uint64_t id;                            // Always valid if GetNonSampleEventInfo succeeded.
         perf_event_attr const* attr;            // Always valid if GetNonSampleEventInfo succeeded.
+        PerfEventSessionInfo const* session;    // Always valid if GetNonSampleEventInfo succeeded.
         _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
         uint64_t sample_type;                   // Bit set if corresponding info present in event.
         uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventSessionInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventSessionInfo.h
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef _included_PerfEventSessionInfo_h
+#define _included_PerfEventSessionInfo_h
+
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <sal.h>
+#endif
+#ifndef _In_reads_bytes_
+#define _In_reads_bytes_(cb)
+#endif
+
+namespace tracepoint_decode
+{
+    // Semantics equivalent to struct timespec from <time.h>.
+    struct PerfEventTimeSpec
+    {
+        int64_t tv_sec;     // Seconds since 1970.
+        uint32_t tv_nsec;   // Nanoseconds.
+    };
+
+    class PerfEventSessionInfo
+    {
+        int64_t m_clockOffsetSec;
+        uint32_t m_clockOffsetNsec;
+        uint32_t m_clockId;
+        bool m_clockOffsetKnown;
+
+    public:
+
+        constexpr
+        PerfEventSessionInfo() noexcept
+            : m_clockOffsetSec(0)
+            , m_clockOffsetNsec(0)
+            , m_clockId(0xFFFFFFFF)
+            , m_clockOffsetKnown(false)
+        {
+            return;
+        }
+
+        // From HEADER_CLOCKID. If unknown, use SetClockid(0xFFFFFFFF).
+        void
+        SetClockid(uint32_t clockid) noexcept;
+
+        // From HEADER_CLOCK_DATA. If unknown, use SetClockData(0xFFFFFFFF, 0, 0).
+        void
+        SetClockData(uint32_t clockid, uint64_t wallClockNS, uint64_t clockidTimeNS) noexcept;
+
+        // Returns the clockid of the session timestamp, e.g. CLOCK_MONOTONIC.
+        // Returns 0xFFFFFFFF if the session timestamp clockid is unknown.
+        uint32_t
+        ClockId() const noexcept;
+
+        // Returns the CLOCK_REALTIME value that corresponds to an event timestamp of 0
+        // for this session. Returns 1970 if the session timestamp offset is unknown.
+        PerfEventTimeSpec
+        ClockOffset() const noexcept;
+
+        // Returns true if session clock offset is known.
+        bool
+        ClockOffsetKnown() const noexcept;
+
+        // Converts time from session timestamp to real-time (time since 1970):
+        // TimeToRealTime = ClockOffset() + time.
+        // If session clock offset is unknown, assume 1970.
+        PerfEventTimeSpec
+        TimeToRealTime(uint64_t time) const noexcept;
+    };
+}
+// namespace tracepoint_decode
+
+#endif // _included_PerfEventSessionInfo_h

--- a/libtracepoint-decode-cpp/src/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/src/CMakeLists.txt
@@ -3,7 +3,8 @@ add_library(tracepoint-decode
     PerfByteReader.cpp
     PerfDataFile.cpp
     PerfEventAbi.cpp
-    PerfEventMetadata.cpp)
+    PerfEventMetadata.cpp
+    PerfEventSessionInfo.cpp)
 target_include_directories(tracepoint-decode
     PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>"
@@ -13,7 +14,8 @@ set(DECODE_HEADERS
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfDataFile.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventAbi.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventInfo.h"
-    "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventMetadata.h")
+    "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventMetadata.h"
+    "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventSessionInfo.h")
 set_target_properties(tracepoint-decode PROPERTIES
     PUBLIC_HEADER "${DECODE_HEADERS}")
 target_compile_features(tracepoint-decode

--- a/libtracepoint-decode-cpp/src/PerfEventSessionInfo.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventSessionInfo.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <tracepoint/PerfEventSessionInfo.h>
+#include <stdio.h>
+
+using namespace tracepoint_decode;
+
+static auto const Billion = 1000000000u;
+
+void
+PerfEventSessionInfo::SetClockid(
+    uint32_t clockid) noexcept
+{
+    m_clockId = clockid;
+}
+
+void
+PerfEventSessionInfo::SetClockData(
+    uint32_t clockid,
+    uint64_t wallClockNS,
+    uint64_t clockidTimeNS) noexcept
+{
+    if (clockid == 0xFFFFFFFF)
+    {
+        // Offset is unspecified.
+
+        m_clockOffsetSec = 0;
+        m_clockOffsetNsec = 0;
+        m_clockId = clockid;
+        m_clockOffsetKnown = false;
+    }
+    else if (clockidTimeNS <= wallClockNS)
+    {
+        // Offset is positive.
+
+        // wallClockNS = clockidTimeNS + offsetNS
+        // offsetNS = wallClockNS - clockidTimeNS
+        auto const offsetNS = wallClockNS - clockidTimeNS;
+
+        // offsetNS = sec * Billion + nsec
+
+        // sec = offsetNS / Billion
+        m_clockOffsetSec = static_cast<int64_t>(offsetNS / Billion);
+
+        // nsec = offsetNS % Billion
+        m_clockOffsetNsec = static_cast<uint32_t>(offsetNS % Billion);
+
+        m_clockId = clockid;
+        m_clockOffsetKnown = true;
+    }
+    else
+    {
+        // Offset is negative.
+
+        // wallClockNS = clockidTimeNS + offsetNS
+        // offsetNS = wallClockNS - clockidTimeNS
+        // -negOffsetNS = wallClockNS - clockidTimeNS
+        // negOffsetNS = clockidTimeNS - wallClockNS
+        auto const negOffsetNS = clockidTimeNS - wallClockNS;
+
+        // negOffsetNS = (negOffsetNS / Billion) * Billion + (negOffsetNS % Billion)
+        // negOffsetNS = (negOffsetNS / Billion) * Billion + (negOffsetNS % Billion) - Billion + Billion
+        // negOffsetNS = (negOffsetNS / Billion + 1) * Billion + (negOffsetNS % Billion) - Billion
+
+        // negOffsetNS = negSec * Billion + negNsec
+        // negSec = negOffsetNS / Billion + 1
+        // negNsec = (negOffsetNS % Billion) - Billion
+
+        // sec = -(negOffsetNS / Billion + 1)
+        m_clockOffsetSec = -static_cast<int64_t>(negOffsetNS / Billion) - 1;
+
+        // nsec = -((negOffsetNS % Billion) - Billion)
+        m_clockOffsetNsec = Billion - static_cast<uint32_t>(negOffsetNS % Billion);
+
+        // Fix up case where nsec is too large.
+        if (m_clockOffsetNsec == Billion)
+        {
+            m_clockOffsetSec += 1;
+            m_clockOffsetNsec -= Billion;
+        }
+
+        m_clockId = clockid;
+        m_clockOffsetKnown = true;
+    }
+}
+
+uint32_t
+PerfEventSessionInfo::ClockId() const noexcept
+{
+    return m_clockId;
+}
+
+PerfEventTimeSpec
+PerfEventSessionInfo::ClockOffset() const noexcept
+{
+    return { m_clockOffsetSec, m_clockOffsetNsec };
+}
+
+bool
+PerfEventSessionInfo::ClockOffsetKnown() const noexcept
+{
+    return m_clockOffsetKnown;
+}
+
+PerfEventTimeSpec
+PerfEventSessionInfo::TimeToRealTime(uint64_t time) const noexcept
+{
+    auto sec = static_cast<int64_t>(time / Billion);
+    auto nsec = static_cast<uint32_t>(time % Billion);
+    sec += m_clockOffsetSec;
+    nsec += m_clockOffsetNsec;
+    if (nsec >= Billion)
+    {
+        sec += 1;
+        nsec -= Billion;
+    }
+    return { sec, nsec };
+}

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,3 +1,0 @@
-# EventHeader for Rust
-
-Moved to: [LinuxTracepoints-Rust](https://github.com/microsoft/LinuxTracepoints-Rust)


### PR DESCRIPTION
The existing library tracks event timestamp as a nanosecond offset from some unknown reference time. This allows determining event order and the time between events, but it does not help when determining the date/time an event occurred. For that, we need to know the wall-clock time corresponding to that reference time.

This PR adds support for tracking the "clock information" for a session, which includes the clock type (e.g. MONOTONIC or REALTIME) and the wall-clock date/time that a `0` timestamp value indicates. This information may not always be available.

Details:

- Define a type for session metadata. Include clock information in this type.
- Add a pointer to the session metadata to the event metadata.
- When parsing a `perf.data` file that contains clock information, record it in the session metadata. (A `perf.data` file will contain clock information if the `-k` option was used, e.g. `perf record -k monotonic -e ...`).
- When running a live session, record the clock information in the session metadata.
- When formatting an event, if clock information is available, format as `"yyyy-mm-ddThh:mm:ss.nnnnnnnnnZ"`. If clock information is not available, fall back to the existing `ss.nnnnnnnnn` format.
- Update version to 1.3 for the affected libraries. Unaffected libraries remain at 1.2.