### PR TITLE
Probe for debugfs is still needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,10 @@
 - Changed procedure for locating the `user_events_data` file.
   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
     point, then use that as the root for the `user_events_data` path.
-  - New: try `/sys/kernel/tracing/user_events_data`, then parse `/proc/mounts`
-    to find the tracefs mount point (i.e. only parse `/proc/mounts` if the
-    absolute path doesn't exist, and only look for tracefs, not debugfs).
-  - Rationale: If `debugfs` is mounted then `tracefs` is always also mounted,
-    so we don't ever need to look for `debugfs`. Probe the absolute path so
-    that containers don't have to create a fake `/proc/mounts` and for startup
-    efficiency.
+  - New: try `/sys/kernel/tracing/user_events_data`; if that doesn't exist,
+    parse `/proc/mounts` to find the `tracefs` or `debugfs` mount point.
+  - Rationale: Probe an absolute path so that containers don't have to
+    create a fake `/proc/mounts` and for efficiency.
 
 ## v1.2.1 (2023-07-24)
 

--- a/libeventheader-tracepoint/include/eventheader/TraceLoggingProvider.h
+++ b/libeventheader-tracepoint/include/eventheader/TraceLoggingProvider.h
@@ -9,7 +9,7 @@ Prerequisites:
 
 - If prerequisites are not met then register/write/unregister will be no-ops.
 - Kernel must be built with tracefs and UserEvents (CONFIG_USER_EVENTS=y).
-- tracefs mounted (e.g. /sys/kernel/tracing).
+- tracefs mounted (e.g. /sys/kernel/tracing or /sys/kernel/debug/tracing).
 - Caller must have appropriate permissions: x on tracefs mount point,
   rw on tracefs/user_events_data.
 

--- a/libtracepoint-control-cpp/include/tracepoint/TracepointPath.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointPath.h
@@ -29,16 +29,17 @@ information.
 namespace tracepoint_control
 {
     /*
-    Returns the path to the "/sys/.../tracing" directory, usually
-    "/sys/kernel/tracing".
+    Returns the path to the "/sys/.../tracing" directory, usually either
+    "/sys/kernel/tracing" or "/sys/kernel/debug/tracing".
 
     Returns "" if no tracing directory could be found (e.g. tracefs not mounted).
 
     Implementation: The first time this is called, it checks for the existence
-    of "/sys/kernel/tracing" and uses that if it is a directory; otherwise, it
-    parses "/proc/mounts" to find the tracefs mount point ands uses that if
-    present; on failure returns "". Subsequent calls return the cached result.
-    This function is thread-safe.
+    of "/sys/kernel/tracing/events" and if that is a directory, uses
+    "/sys/kernel/tracing"; otherwise, it parses "/proc/mounts" to find the
+    tracefs or debugfs mount point and uses the corresponding ".../tracing"
+    directory if a mount point is listed; otherwise, returns "".
+    Subsequent calls return the cached result. This function is thread-safe.
     */
     _Ret_z_ char const*
     GetTracingDirectory() noexcept;
@@ -50,7 +51,7 @@ namespace tracepoint_control
     Do not close the returned descriptor. Use it only for ioctl and writev.
 
     Implementation: The first time this is called, it calls GetTracingDirectory()
-    to find the tracefs mount point, then opens
+    to find the tracefs or debugfs mount point, then opens
     "TracingDirectory/user_events_data" and caches the result. Subsequent calls
     return the cached result. This function is thread-safe.
     */

--- a/libtracepoint/include/tracepoint/tracepoint-provider.h
+++ b/libtracepoint/include/tracepoint/tracepoint-provider.h
@@ -7,9 +7,9 @@ Macros for generating Linux user_events tracepoints via libtracepoint.
 Prerequisites (if not met, register/write/unregister will be no-ops):
 
 - Kernel built with tracefs and UserEvents (CONFIG_USER_EVENTS=y).
-- tracefs mounted (e.g. /sys/kernel/tracing).
+- tracefs mounted (e.g. /sys/kernel/tracing or /sys/kernel/debug/tracing).
 - Caller must have appropriate permissions: x on tracefs mount point,
-  rw on tracing/user_events_data.
+  rw on .../tracing/user_events_data.
 
 Quick start:
 


### PR DESCRIPTION
While `debugfs` will auto-mount `tracefs`, it does so lazily - `tracefs` won't show up in `/proc/mounts` until somebody tries to use it. This means we can't depend on always finding `tracefs` in `/proc/mounts`, so we do need to be able to fall-back to the actual `debugfs` entry.

In addition, the direct probe in TracepointPath.cpp can have a false positive - the `/sys/kernel/tracing` directory can exist without containing a valid mounted `tracefs`. We need to look for something inside the directory if we want an accurate probe, so look for the `events` subdirectory.