### PR TITLE
PerfDataFileWriter - new class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `EventFormatter` formats timestamps as date-time if clock information is
   available in the event metadata. If clock information is not present, it
   continues to format timestamps as seconds.
+- `TracepointSession` now includes ID in default sample type.
 - `TracepointSession` records clock information from the session.
 - `TracepointSession` provides access to information about the tracepoints
    that have been added to the session (metadata, status, statistics).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,26 @@
 
 ## v1.3.0 (TBD)
 
-- `PerfEventInfo.h` adds a field with session information to the metadata of
-  each event. The session information includes clock information.
-- `PerfDataFile.h` decodes clock information from perf.data files if present.
-- `TracepointSession.h` records clock information from the session.
-- `EventFormatter.h` formats timestamps as date-time if clock information is
+- **Breaking changes** to `PerfDataFile` and `PerfSampleEventInfo` classes:
+  - `dataFile.AttrCount()` method replaced by `EventDescCount()` method.
+  - `dataFile.Attr(index)` method replaced by `EventDesc(index)` method.
+    The returned `PerfEventDesc` object contains an `attr` pointer.
+  - `dataFile.EventDescById(id)` method replaced by `FindEventDescById(id)`.
+  - `eventInfo.session` field renamed to `session_info`.
+  - `eventInfo.attr` field replaced by `Attr()` method.
+  - `eventInfo.name` field replaced by `Name()` method.
+  - `eventInfo.sample_type` field replaced by `SampleType()` method.
+  - `eventInfo.raw_meta` field replaced by `Metadata()` method.
+- `EventFormatter` formats timestamps as date-time if clock information is
   available in the event metadata. If clock information is not present, it
   continues to format timestamps as seconds.
+- `TracepointSession` records clock information from the session.
+- `TracepointSession` provides access to information about the tracepoints
+   that have been added to the session (metadata, status, statistics).
+- `PerfDataFile` decodes clock information from perf.data files if present.
+- `PerfDataFile` provides access to more metadata via `PerfEventDesc` struct.
+- `PerfDataFile` provides `EventDataSize` for determining the size of an event.
+- New `PerfDataFileWriter` class for generating `perf.data` files.
 - Changed procedure for locating the `user_events_data` file.
   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
     point, then use that as the root for the `user_events_data` path.

--- a/libeventheader-decode-cpp/tools/decode-perf.cpp
+++ b/libeventheader-decode-cpp/tools/decode-perf.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
                 // Events are returned out-of-order and need to be sorted. Use a map to
                 // put them into timestamp order. Flush the map at the end of each round.
                 auto it = events.emplace(
-                    (sampleEventInfo.sample_type & PERF_SAMPLE_TIME) ? sampleEventInfo.time : 0u,
+                    (sampleEventInfo.SampleType() & PERF_SAMPLE_TIME) ? sampleEventInfo.time : 0u,
                     std::string());
                 err = formatter.AppendSampleAsJson(
                     it->second,

--- a/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
@@ -130,12 +130,13 @@ namespace tracepoint_control
         /*
         The flags that are set in the default value of the SampleType property:
 
+        | PERF_SAMPLE_IDENTIFIER
         | PERF_SAMPLE_TID
         | PERF_SAMPLE_TIME
         | PERF_SAMPLE_CPU
         | PERF_SAMPLE_RAW
         */
-        static constexpr auto SampleTypeDefault = 0x486u;
+        static constexpr auto SampleTypeDefault = 0x10486u;
 
         /*
         The flags that are supported for use with the SampleType property:
@@ -183,14 +184,15 @@ namespace tracepoint_control
         Flags use the perf_event_sample_format values defined in <linux/perf_event.h>
         or <tracepoint/PerfEventAbi.h>.
 
-        The default value is:
+        The following flags are enabled by default (SampleTypeDefault):
 
+        | PERF_SAMPLE_IDENTIFIER
         | PERF_SAMPLE_TID
         | PERF_SAMPLE_TIME
         | PERF_SAMPLE_CPU
         | PERF_SAMPLE_RAW
 
-        The following flags are supported:
+        The following flags are supported (SampleTypeSupported):
 
         | PERF_SAMPLE_IDENTIFIER
         | PERF_SAMPLE_IP
@@ -314,12 +316,7 @@ namespace tracepoint_control
     {
         friend class TracepointInfo;
 
-        // This needs to match the attr.read_format used for tracepoints.
-        struct ReadFormat
-        {
-            uint64_t value;
-            uint64_t id;
-        };
+        struct ReadFormat; // Forward declaration
 
         class unique_fd
         {

--- a/libtracepoint-control-cpp/samples/control-session.cpp
+++ b/libtracepoint-control-cpp/samples/control-session.cpp
@@ -99,7 +99,7 @@ main(int argc, char* argv[])
         error = session.EnumerateSampleEventsUnordered(
             [](PerfSampleEventInfo const& event) -> int
             {
-                auto ts = event.session->TimeToRealTime(event.time);
+                auto ts = event.session_info->TimeToRealTime(event.time);
                 time_t const secs = (time_t)ts.tv_sec;
                 tm t = {};
                 gmtime_r(&secs, &t);
@@ -108,7 +108,7 @@ main(int argc, char* argv[])
                     event.tid,
                     1900 + t.tm_year, 1 + t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, ts.tv_nsec,
                     (long unsigned)event.raw_data_size,
-                    event.name);
+                    event.Name());
                 return 0;
             });
         fprintf(stderr, "Enum: %u, Count=%llu, Lost=%llu, Bad=%llu, BadBuf=%llu\n",

--- a/libtracepoint-decode-cpp/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/CMakeLists.txt
@@ -24,3 +24,4 @@ else()
 endif()
 
 add_subdirectory(src)
+add_subdirectory(samples)

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileDefs.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileDefs.h
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef _included_PerfDataFileDefs_h
+#define _included_PerfDataFileDefs_h
+
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <sal.h>
+#endif
+#ifndef _Field_size_
+#define _Field_size_(size)
+#endif
+#ifndef _Field_z_
+#define _Field_z_
+#endif
+
+// Forward declarations from PerfEventAbi.h or linux/uapi/linux/perf_event.h:
+struct perf_event_attr;
+struct perf_event_header;
+
+namespace tracepoint_decode
+{
+    // Forward declaration from PerfEventMetadata.h:
+    class PerfEventMetadata;
+
+    // uint8 header index.
+    // From: perf.data-file-format.txt, perf/util/header.h.
+    enum PerfHeaderIndex : uint8_t {
+        PERF_HEADER_RESERVED = 0,       // always cleared
+        PERF_HEADER_FIRST_FEATURE = 1,
+        PERF_HEADER_TRACING_DATA = 1,
+        PERF_HEADER_BUILD_ID,
+        PERF_HEADER_HOSTNAME,
+        PERF_HEADER_OSRELEASE,
+        PERF_HEADER_VERSION,
+        PERF_HEADER_ARCH,
+        PERF_HEADER_NRCPUS,
+        PERF_HEADER_CPUDESC,
+        PERF_HEADER_CPUID,
+        PERF_HEADER_TOTAL_MEM,
+        PERF_HEADER_CMDLINE,
+        PERF_HEADER_EVENT_DESC,
+        PERF_HEADER_CPU_TOPOLOGY,
+        PERF_HEADER_NUMA_TOPOLOGY,
+        PERF_HEADER_BRANCH_STACK,
+        PERF_HEADER_PMU_MAPPINGS,
+        PERF_HEADER_GROUP_DESC,
+        PERF_HEADER_AUXTRACE,
+        PERF_HEADER_STAT,
+        PERF_HEADER_CACHE,
+        PERF_HEADER_SAMPLE_TIME,
+        PERF_HEADER_MEM_TOPOLOGY,
+        PERF_HEADER_CLOCKID,
+        PERF_HEADER_DIR_FORMAT,
+        PERF_HEADER_BPF_PROG_INFO,
+        PERF_HEADER_BPF_BTF,
+        PERF_HEADER_COMPRESSED,
+        PERF_HEADER_CPU_PMU_CAPS,
+        PERF_HEADER_CLOCK_DATA,
+        PERF_HEADER_HYBRID_TOPOLOGY,
+        PERF_HEADER_PMU_CAPS,
+        PERF_HEADER_LAST_FEATURE,
+    };
+
+    struct PerfEventDesc
+    {
+        perf_event_attr const* attr;    // NULL for unknown id.
+        _Field_z_ char const* name;     // "" if no name available.
+        PerfEventMetadata const* metadata; // NULL if no metadata available.
+        _Field_size_(ids_count) uint64_t const* ids; // The sample_ids that share this descriptor.
+        uint32_t ids_count;
+    };
+}
+// namespace tracepoint_decode
+
+#endif // _included_PerfDataFileDefs_h

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileWriter.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileWriter.h
@@ -1,0 +1,289 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef _included_PerfDataFileWriter_h
+#define _included_PerfDataFileWriter_h
+
+#include "PerfDataFileDefs.h"
+#include <stdint.h>
+#include <map>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#ifdef _WIN32
+#include <sal.h>
+#endif
+#ifndef _In_
+#define _In_
+#endif
+#ifndef _In_z_
+#define _In_z_
+#endif
+#ifndef _In_reads_
+#define _In_reads_(count)
+#endif
+#ifndef _In_reads_bytes_
+#define _In_reads_bytes_(cb)
+#endif
+#ifndef _Out_
+#define _Out_
+#endif
+#ifndef _Outptr_result_maybenull_
+#define _Outptr_result_maybenull_
+#endif
+#ifndef _Out_writes_bytes_all_
+#define _Out_writes_bytes_all_(size)
+#endif
+#ifndef _Field_z_
+#define _Field_z_
+#endif
+#ifndef _Field_size_bytes_
+#define _Field_size_bytes_(size)
+#endif
+#ifndef _Success_
+#define _Success_(condition)
+#endif
+
+#ifndef _WIN32
+
+// Forward declaration from sys/uio.h:
+struct iovec;
+
+#endif // !_WIN32
+
+namespace tracepoint_decode
+{
+    /*
+    PerfDataFileWriter class - Writes perf.data files.
+
+    - Construct a writer: PerfDataFileWriter writer;
+    - Open the file: writer.Create(filename);
+      - This writes headers and positions the file pointer for event data.
+    - Do the following (in any order):
+      - Call WriteEventData to write event data to the file.
+      - Call AddTracepointEventDesc() to provide event information for events
+        with tracefs format information.
+      - Call AddEventDesc() to provide event information for events that don't
+        have tracefs format information.
+      - Call SetHeader() to provide data for other headers in the file.
+    - Close the file: writer.Close();
+      - This writes the file footers, finalizes the headers, then closes the file.
+    */
+    class PerfDataFileWriter
+    {
+        struct perf_file_section;
+        struct perf_file_header;
+        struct EventDesc;
+        struct TracepointInfo;
+
+        uint64_t m_filePos;
+        int m_file;
+        std::vector<EventDesc> m_eventDescs;
+        std::map<uint32_t, TracepointInfo> m_tracepointInfoByCommonType;
+        std::vector<char> m_headers[PERF_HEADER_LAST_FEATURE];
+
+        uint32_t m_tracingDataPageSize;
+        uint8_t m_tracingDataLongSize;
+        std::vector<char> m_tracingDataHeaderPage;
+        std::vector<char> m_tracingDataHeaderEvent;
+        std::vector<std::vector<char>> m_tracingDataFtraces;
+        std::vector<char> m_tracingDataKallsyms;
+        std::vector<char> m_tracingDataPrintk;
+        std::vector<char> m_tracingDataSavedCmdline;
+
+    public:
+
+        PerfDataFileWriter(PerfDataFileWriter const&) = delete;
+        void operator=(PerfDataFileWriter const&) = delete;
+
+        // Calls CloseNoFinalize.
+        ~PerfDataFileWriter() noexcept;
+
+        // May throw bad_alloc.
+        PerfDataFileWriter() noexcept(false);
+
+        // Immediately closes the current output file (if any).
+        // Does not finalize headers - resulting file will not be usable.
+        void
+        CloseNoFinalize() noexcept;
+
+        // Writes footer, finalizes header, and closes the output file.
+        // On error, closes the output file and returns errno.
+        _Success_(return == 0) int
+        FinalizeAndClose() noexcept;
+
+        // Calls CloseNoFinalize() to close any previous output file, then creates a new
+        // file using open(filePath, O_CREAT|O_WRONLY|O_TRUNC|O_CLOEXEC, mode) and
+        // writes the file header. On error, closes the output file and returns errno.
+        _Success_(return == 0) int
+        Create(_In_z_ char const* filePath, int mode = -1) noexcept;
+
+        // Returns the file offset at which the next call to WriteEventData()
+        // will begin writing. Returns -1 if file is closed.
+        uint64_t
+        FilePos() const noexcept;
+
+        // Adds a block of event data to the output file.
+        // Data should be a sequence of perf_event_header blocks, i.e. a
+        // perf_event_header, then data, then another perf_event_header, etc.
+        //
+        // On success, returns 0. On error, returns errno, in which case file state is
+        // unspecified (may have written some but not all of the data to the file).
+        //
+        // Notes:
+        // - The content of the data is written directly to the event data section of
+        //   the output file without any validation.
+        // - dataSize should always be a multiple of 8.
+        // - dataSize should almost always be the sum of hdr.size for all headers written,
+        //   except for PERF_RECORD_HEADER_TRACING_DATA and PERF_RECORD_AUXTRACE which may
+        //   have additional data in the block beyond the size indicated in the header.
+        // - The trace file will be invalid if any events are written with an id
+        //   field that does not have a corresponding entry in the EventDesc table. You
+        //   need to provide that information by calling AddTracepointEventDesc(...) or
+        //   AddEventDesc(...).
+        _Success_(return == 0) int
+        WriteEventData(
+            _In_reads_bytes_(dataSize) void const* data,
+            size_t dataSize) noexcept;
+
+#ifndef _WIN32
+
+        // Advanced: Adds blocks of event data to the output file.
+        // Similar to WriteEventData, but accepts multiple blocks of data and returns
+        // the number of bytes written instead of errno.
+        //
+        // On error, returns -1.
+        // On success, returns number of bytes written. In rare cases, may succeed with a
+        // result less than dataSize (see writev(2) documentation).
+        _Success_(return >= 0) ptrdiff_t
+        WriteEventDataIovecs(
+            _In_reads_(iovecsCount) struct iovec const* iovecs,
+            int iovecsCount) noexcept;
+
+#endif // !_WIN32
+
+        // Returns the number of bytes set for the specified header.
+        size_t
+        GetHeaderSize(PerfHeaderIndex index) const noexcept;
+
+        // Returns a pointer to the data set for the specified header.
+        void const*
+        GetHeaderData(PerfHeaderIndex index) const noexcept;
+
+        // Directly sets or resets the data for the specified header.
+        //
+        // Note that the PerfDataFileWriter class has special support for the
+        // following headers:
+        //
+        // - If no data has been set via SetHeader(PERF_HEADER_TRACING_DATA, ...)
+        //   then the PERF_HEADER_TRACING_DATA header will be synthesized using
+        //   data supplied via AddTracepointEventDesc(...) and SetTracingData(...). 
+        // - If no data has been set via SetHeader(PERF_HEADER_EVENT_DESC, ...)
+        //   then the PERF_HEADER_EVENT_DESC header will be synthesized using data
+        //   supplied via AddTracepointEventDesc(...) and AddEventDesc(...).
+        _Success_(return == 0) int
+        SetHeader(
+            PerfHeaderIndex index,
+            _In_reads_bytes_(dataSize) void const* data,
+            size_t dataSize) noexcept;
+
+        // Configures information to be included in the synthesized
+        // PERF_HEADER_TRACING_DATA header. These settings are given default values
+        // when the PerfDataFileWriter is constructed. These settings are used when
+        // writing a file for which no data was provided via
+        // SetHeader(PERF_HEADER_TRACING_DATA, ...).
+        // 
+        // For all of the parameters, a 0 or {NULL, 0} value indicates "keep the
+        // existing value". To indicate "set the value to empty", use {non-null, 0}.
+        //
+        // - longSize: Default is sizeof(size_t).
+        // - pageSize: Default is sysconf(_SC_PAGESIZE).
+        // - headerPage: Default is timestamp64+commit64+overwrite8+data4080. Empty means use default.
+        // - headerEvent: Default is type_len5, time_delta27, array32. Empty means use default.
+        // - ftraces: Default is "".
+        // - kallsyms: Default is "".
+        // - printk: Default is "".
+        // - savedCmdLine: Default is "".
+        _Success_(return == 0) int
+        SetTracingData(
+            uint8_t longSize,
+            uint32_t pageSize,
+            std::string_view headerPage,
+            std::string_view headerEvent,
+            _In_reads_(ftraceCount) std::string_view const* ftraces,
+            uint32_t ftraceCount,
+            std::string_view kallsyms,
+            std::string_view printk,
+            std::string_view savedCmdLine) noexcept;
+
+        // Adds perf_event_attr and name information for the specified event ids.
+        // Use this for events that do NOT have tracefs format information, i.e.
+        // when desc.metadata == NULL.
+        // 
+        // Requires: desc.attr != NULL, desc.name != NULL.
+        //
+        // Returns 0 for success, errno for error.
+        // Returns E2BIG if desc.name is 64KB or longer.
+        //
+        // Note that each id used in the trace should map to exactly one attr provided
+        // by AddTracepointEventDesc or AddEventDesc, but this is not validated by
+        // PerfDataFileWriter. For example, if the same id is provided in two different
+        // calls to AddEventDesc, the resulting file may not decode properly.
+        _Success_(return == 0) int
+        AddEventDesc(PerfEventDesc const& desc) noexcept;
+
+        // Returns true if there has been a successful call to
+        // AddTracepointEventDesc(desc) where desc.metadata->Id() == common_type.
+        bool
+        HasTracepointEventDesc(uint32_t common_type) const noexcept;
+
+        // Adds metadata for the event specified by desc.metadata->Id().
+        // If metadata is already set for that event, returns EEXIST.
+        // Use this for events that DO have tracefs format information, i.e.
+        // when desc.metadata != NULL.
+        //
+        // Requires: desc.attr != NULL, desc.name != NULL, desc.metadata != NULL.
+        // Also, desc.metadata is copied by reference (shallow copy).
+        //
+        // Returns 0 for success, errno for error.
+        // Returns E2BIG if desc.name is 64KB or longer.
+        //
+        // Note that each id used in the trace should map to exactly one attr provided
+        // by AddTracepointEventDesc or AddEventDesc, but this is not validated by
+        // PerfDataFileWriter. For example, if the same id is provided in two different
+        // calls to AddEventDesc, the resulting file may not decode properly.
+        _Success_(return == 0) int
+        AddTracepointEventDesc(PerfEventDesc const& desc) noexcept;
+
+    private:
+
+        bool
+        ValidFilePos() const noexcept;
+
+        _Success_(return == 0) int
+        WriteData(
+            _In_reads_bytes_(dataSize) void const* data,
+            size_t dataSize) noexcept;
+
+        void
+        SynthesizeTracingData();
+
+        void
+        SynthesizeEventDesc();
+
+        // Writes the perf_file_sections for m_headers,
+        // then writes the data from m_headers.
+        _Success_(return == 0) int
+        WriteHeaders(_Out_ uint64_t* pFlags0) noexcept;
+
+        // Writes the attr+idSection for each attr.
+        // Then writes the id data.
+        _Success_(return == 0) int
+        WriteAttrs(_Out_ perf_file_section* pAttrsSection) noexcept;
+    };
+}
+// namespace tracepoint_decode
+
+#endif // _included_PerfDataFileWriter_h

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
@@ -36,8 +36,8 @@ namespace tracepoint_decode
 
     struct PerfSampleEventInfo
     {
-        PerfEventDesc const* event_desc;        // Always valid if GetSampleEventInfo succeeded.
-        PerfEventSessionInfo const* session_info;//Always valid if GetSampleEventInfo succeeded.
+        PerfEventDesc const* event_desc;        // Always valid if GetSampleEventInfo() succeeded.
+        PerfEventSessionInfo const* session_info;//Always valid if GetSampleEventInfo() succeeded.
         uint64_t id;                            // Valid if SampleType() & (PERF_SAMPLE_IDENTIFIER | PERF_SAMPLE_ID).
         uint32_t pid, tid;                      // Valid if SampleType() & PERF_SAMPLE_TID.
         uint64_t time;                          // Valid if SampleType() & PERF_SAMPLE_TIME.
@@ -52,6 +52,11 @@ namespace tracepoint_decode
         uintptr_t raw_data_size;                // Valid if SampleType() & PERF_SAMPLE_RAW. Size of raw_data.
 
         // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->attr->sample_type.
+        uint64_t
+        SampleType() const noexcept;
+
+        // Requires: GetSampleEventInfo() succeeded.
         // Returns: event_desc->attr.
         perf_event_attr const&
         Attr() const noexcept;
@@ -60,11 +65,6 @@ namespace tracepoint_decode
         // Returns: event_desc->name.
         _Ret_z_ char const*
         Name() const noexcept;
-
-        // Requires: GetSampleEventInfo() succeeded.
-        // Returns: event_desc->attr->sample_type.
-        uint64_t
-        SampleType() const noexcept;
 
         // Requires: GetSampleEventInfo() succeeded.
         // Returns: event_desc->metadata (may be NULL).
@@ -75,28 +75,28 @@ namespace tracepoint_decode
 
     struct PerfNonSampleEventInfo
     {
-        PerfEventDesc const* event_desc;        // Always valid if GetNonSampleEventInfo succeeded.
-        PerfEventSessionInfo const* session_info;//Always valid if GetNonSampleEventInfo succeeded.
+        PerfEventDesc const* event_desc;        // Always valid if GetNonSampleEventInfo() succeeded.
+        PerfEventSessionInfo const* session_info;//Always valid if GetNonSampleEventInfo() succeeded.
         uint64_t id;                            // Valid if SampleType() & (PERF_SAMPLE_IDENTIFIER | PERF_SAMPLE_ID).
         uint32_t pid, tid;                      // Valid if SampleType() & PERF_SAMPLE_TID.
         uint64_t time;                          // Valid if SampleType() & PERF_SAMPLE_TIME.
         uint64_t stream_id;                     // Valid if SampleType() & PERF_SAMPLE_STREAM_ID.
         uint32_t cpu, cpu_reserved;             // Valid if SampleType() & PERF_SAMPLE_CPU.
 
-        // Requires: GetSampleEventInfo() succeeded.
+        // Requires: GetNonSampleEventInfo() succeeded.
+        // Returns: event_desc->attr->sample_type.
+        uint64_t
+        SampleType() const noexcept;
+
+        // Requires: GetNonSampleEventInfo() succeeded.
         // Returns: event_desc->attr.
         perf_event_attr const&
         Attr() const noexcept;
 
-        // Requires: GetSampleEventInfo() succeeded.
+        // Requires: GetNonSampleEventInfo() succeeded.
         // Returns: event_desc->name.
         _Ret_z_ char const*
         Name() const noexcept;
-
-        // Requires: GetSampleEventInfo() succeeded.
-        // Returns: event_desc->attr->sample_type.
-        uint64_t
-        SampleType() const noexcept;
     };
 }
 // namespace tracepoint_decode

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
@@ -10,11 +10,14 @@
 #ifdef _WIN32
 #include <sal.h>
 #endif
-#ifndef _Field_z_
-#define _Field_z_
-#endif
 #ifndef _Field_size_bytes_
 #define _Field_size_bytes_(size)
+#endif
+#ifndef _Ret_z_
+#define _Ret_z_
+#endif
+#ifndef _Ret_opt_
+#define _Ret_opt_
 #endif
 
 // Forward declaration from PerfEventAbi.h or linux/uapi/linux/perf_event.h:
@@ -22,6 +25,9 @@ struct perf_event_attr;
 
 namespace tracepoint_decode
 {
+    // Forward declaration from PerfDataFileDefs.h:
+    struct PerfEventDesc;
+
     // Forward declaration from PerfEventSessionInfo.h:
     class PerfEventSessionInfo;
 
@@ -30,36 +36,67 @@ namespace tracepoint_decode
 
     struct PerfSampleEventInfo
     {
-        uint64_t id;                            // Always valid if GetSampleEventInfo succeeded.
-        perf_event_attr const* attr;            // Always valid if GetSampleEventInfo succeeded.
-        PerfEventSessionInfo const* session;    // Always valid if GetSampleEventInfo succeeded.
-        _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
-        uint64_t sample_type;                   // Bit set if corresponding info present in event.
-        uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
-        uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
-        uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
-        uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
-        uint64_t ip;                            // Valid if sample_type & PERF_SAMPLE_IP.
-        uint64_t addr;                          // Valid if sample_type & PERF_SAMPLE_ADDR.
-        uint64_t period;                        // Valid if sample_type & PERF_SAMPLE_PERIOD.
-        uint64_t const* read_values;            // Valid if sample_type & PERF_SAMPLE_READ. Points into event.
-        uint64_t const* callchain;              // Valid if sample_type & PERF_SAMPLE_CALLCHAIN. Points into event.
-        PerfEventMetadata const* raw_meta;      // Valid if sample_type & PERF_SAMPLE_RAW. NULL if event unknown.
-        _Field_size_bytes_(raw_data_size) void const* raw_data; // Valid if sample_type & PERF_SAMPLE_RAW. Points into event.
-        uintptr_t raw_data_size;                // Valid if sample_type & PERF_SAMPLE_RAW. Size of raw_data.
+        PerfEventDesc const* event_desc;        // Always valid if GetSampleEventInfo succeeded.
+        PerfEventSessionInfo const* session_info;//Always valid if GetSampleEventInfo succeeded.
+        uint64_t id;                            // Valid if SampleType() & (PERF_SAMPLE_IDENTIFIER | PERF_SAMPLE_ID).
+        uint32_t pid, tid;                      // Valid if SampleType() & PERF_SAMPLE_TID.
+        uint64_t time;                          // Valid if SampleType() & PERF_SAMPLE_TIME.
+        uint64_t stream_id;                     // Valid if SampleType() & PERF_SAMPLE_STREAM_ID.
+        uint32_t cpu, cpu_reserved;             // Valid if SampleType() & PERF_SAMPLE_CPU.
+        uint64_t ip;                            // Valid if SampleType() & PERF_SAMPLE_IP.
+        uint64_t addr;                          // Valid if SampleType() & PERF_SAMPLE_ADDR.
+        uint64_t period;                        // Valid if SampleType() & PERF_SAMPLE_PERIOD.
+        uint64_t const* read_values;            // Valid if SampleType() & PERF_SAMPLE_READ. Points into event.
+        uint64_t const* callchain;              // Valid if SampleType() & PERF_SAMPLE_CALLCHAIN. Points into event.
+        _Field_size_bytes_(raw_data_size) void const* raw_data; // Valid if SampleType() & PERF_SAMPLE_RAW. Points into event.
+        uintptr_t raw_data_size;                // Valid if SampleType() & PERF_SAMPLE_RAW. Size of raw_data.
+
+        // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->attr.
+        perf_event_attr const&
+        Attr() const noexcept;
+
+        // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->name.
+        _Ret_z_ char const*
+        Name() const noexcept;
+
+        // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->attr->sample_type.
+        uint64_t
+        SampleType() const noexcept;
+
+        // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->metadata (may be NULL).
+        // Valid if SampleType() & PERF_SAMPLE_RAW.
+        _Ret_opt_ PerfEventMetadata const*
+        Metadata() const noexcept;
     };
 
     struct PerfNonSampleEventInfo
     {
-        uint64_t id;                            // Always valid if GetNonSampleEventInfo succeeded.
-        perf_event_attr const* attr;            // Always valid if GetNonSampleEventInfo succeeded.
-        PerfEventSessionInfo const* session;    // Always valid if GetNonSampleEventInfo succeeded.
-        _Field_z_ char const* name;             // e.g. "system:tracepoint", or "" if no name available.
-        uint64_t sample_type;                   // Bit set if corresponding info present in event.
-        uint32_t pid, tid;                      // Valid if sample_type & PERF_SAMPLE_TID.
-        uint64_t time;                          // Valid if sample_type & PERF_SAMPLE_TIME.
-        uint64_t stream_id;                     // Valid if sample_type & PERF_SAMPLE_STREAM_ID.
-        uint32_t cpu, cpu_reserved;             // Valid if sample_type & PERF_SAMPLE_CPU.
+        PerfEventDesc const* event_desc;        // Always valid if GetNonSampleEventInfo succeeded.
+        PerfEventSessionInfo const* session_info;//Always valid if GetNonSampleEventInfo succeeded.
+        uint64_t id;                            // Valid if SampleType() & (PERF_SAMPLE_IDENTIFIER | PERF_SAMPLE_ID).
+        uint32_t pid, tid;                      // Valid if SampleType() & PERF_SAMPLE_TID.
+        uint64_t time;                          // Valid if SampleType() & PERF_SAMPLE_TIME.
+        uint64_t stream_id;                     // Valid if SampleType() & PERF_SAMPLE_STREAM_ID.
+        uint32_t cpu, cpu_reserved;             // Valid if SampleType() & PERF_SAMPLE_CPU.
+
+        // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->attr.
+        perf_event_attr const&
+        Attr() const noexcept;
+
+        // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->name.
+        _Ret_z_ char const*
+        Name() const noexcept;
+
+        // Requires: GetSampleEventInfo() succeeded.
+        // Returns: event_desc->attr->sample_type.
+        uint64_t
+        SampleType() const noexcept;
     };
 }
 // namespace tracepoint_decode

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventMetadata.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventMetadata.h
@@ -164,6 +164,7 @@ namespace tracepoint_decode
     class PerfEventMetadata
     {
         std::string_view m_systemName;
+        std::string_view m_formatFileContents;
         std::string_view m_name;
         std::string_view m_printFmt;
         std::vector<PerfFieldMetadata> m_fields;
@@ -180,6 +181,11 @@ namespace tracepoint_decode
         // Returns the value of the systemName parameter, e.g. "user_events".
         constexpr std::string_view
         SystemName() const noexcept { return m_systemName; }
+
+        // Returns the value of the formatFileContents parameter, e.g.
+        // "name: my_event\nID: 1234\nformat:...".
+        constexpr std::string_view
+        FormatFileContents() const noexcept { return m_formatFileContents; }
 
         // Returns the value of the "name:" property, e.g. "my_event".
         constexpr std::string_view

--- a/libtracepoint-decode-cpp/samples/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/samples/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(perf-file-rewrite
+    perf-file-rewrite.cpp)
+target_link_libraries(perf-file-rewrite
+    tracepoint-decode)
+target_compile_features(perf-file-rewrite
+    PRIVATE cxx_std_17)

--- a/libtracepoint-decode-cpp/samples/perf-file-rewrite.cpp
+++ b/libtracepoint-decode-cpp/samples/perf-file-rewrite.cpp
@@ -1,0 +1,341 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/*
+Sample tool that demonstrates reading a perf.data file with PerfDataFile and
+writing a perf.data file with PerfDataFileWriter.
+
+This is not intended to be useful (except perhaps for testing purposes). It is
+intended to show how PerfDataFile can be used to take the perf.data file
+apart and how PerfDataFileWriter can put it back together.
+
+Note that the output file is not expected to be exactly the same as the input:
+
+- Output is always a normal-mode file even if input was a pipe-mode file.
+- Output file may store headers in a different order.
+- Output file may use more/less padding.
+- If the input file is semantically inconsistent, the output file may not
+  precisely match the input (the inconsistent data might be lost). For
+  example, there are usually two (or more) copies of each attr, one in a
+  v1 format and another in a v2 format. The rewrite process will typically
+  ignore the v1 copy of the data if a v2 copy is available, so if the v1 copy
+  is semantically different from the v2 copy, that detail might be lost during
+  rewrite.
+*/
+
+#include <tracepoint/PerfDataFile.h>
+#include <tracepoint/PerfDataFileWriter.h>
+#include <tracepoint/PerfEventAbi.h>
+#include <tracepoint/PerfEventInfo.h>
+#include <tracepoint/PerfEventMetadata.h>
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#ifdef _WIN32
+#define strerror_r(errnum, buf, buflen) (strerror_s(buf, buflen, errnum), buf)
+#define UNLINK(filename) _unlink(filename)
+#else
+#include <unistd.h>
+#define UNLINK(filename) unlink(filename)
+#endif // _WIN32
+
+using namespace tracepoint_decode;
+
+static void
+WriteErrorMessage(char const* filename, int error, char const* context)
+{
+    if (error == ENOMEM)
+    {
+        throw std::bad_alloc();
+    }
+
+    char errorBuf[80];
+    fprintf(stderr, "%s: error %u : %s (%s).\n",
+        filename,
+        error,
+        context,
+        strerror_r(error, errorBuf, sizeof(errorBuf)));
+}
+
+static void
+WriteWarningMessage(char const* filename, int error, char const* context)
+{
+    if (error == ENOMEM)
+    {
+        throw std::bad_alloc();
+    }
+
+    char errorBuf[80];
+    fprintf(stderr, "%s: warning %u : %s (%s).\n",
+        filename,
+        error,
+        context,
+        strerror_r(error, errorBuf, sizeof(errorBuf)));
+}
+
+static void
+MergeEventDesc(
+    PerfDataFileWriter& output,
+    char const* outputPath,
+    std::unordered_set<uint64_t>& sampleIdsUsed,
+    std::vector<uint64_t>& sampleIdsBuffer,
+    PerfEventDesc const& desc)
+{
+    sampleIdsBuffer.clear();
+    for (uint32_t iId = 0; iId != desc.ids_count; iId += 1)
+    {
+        auto const id = desc.ids[iId];
+        if (sampleIdsUsed.insert(desc.ids[iId]).second)
+        {
+            sampleIdsBuffer.push_back(id);
+        }
+    }
+
+    if (!sampleIdsBuffer.empty())
+    {
+        PerfEventDesc newDesc = desc;
+        newDesc.ids = sampleIdsBuffer.data();
+        newDesc.ids_count = static_cast<uint32_t>(sampleIdsBuffer.size());
+        auto err = output.AddEventDesc(newDesc);
+        if (err != 0)
+        {
+            WriteWarningMessage(outputPath, err, "output.AddEventDesc failed, metadata incomplete");
+        }
+    }
+}
+
+int
+main(int argc, char* argv[])
+{
+    bool mainSuccessful = false;
+
+    if (argc <= 1)
+    {
+        fprintf(stderr, "\nUsage: %s [perf.data] ... (will generate *.rewrite)\n",
+            argv[0]);
+    }
+    else try
+    {
+        PerfDataFile input;
+        PerfDataFileWriter output;
+        std::string outputPathBuffer;
+        std::vector<uint64_t> sampleIdsBuffer;
+        std::unordered_set<uint64_t> sampleIdsUsed;
+
+        for (int argi = 1; argi < argc; argi += 1)
+        {
+            int err;
+            auto const inputPath = argv[argi];
+            outputPathBuffer = inputPath;
+            outputPathBuffer += ".rewrite";
+            auto const outputPath = outputPathBuffer.c_str();
+
+            err = input.Open(inputPath);
+            if (err != 0)
+            {
+                WriteErrorMessage(inputPath, err, "input.Open failed, skipping file");
+                continue;
+            }
+
+            if (input.ByteReader().ByteSwapNeeded())
+            {
+                // PerfDataFileWriter only supports creating host-endian files, so we can't
+                // easily rewrite a byte-swapped input file.
+                err = ENOTSUP;
+                WriteErrorMessage(inputPath, err, "input is byte-swapped, skipping file");
+                continue;
+            }
+
+            err = output.Create(outputPath);
+            if (err != 0)
+            {
+                WriteErrorMessage(outputPath, err, "output.Create failed, skipping file");
+                continue;
+            }
+
+            sampleIdsUsed.clear();
+            for (;;)
+            {
+                perf_event_header const* pHeader;
+                err = input.ReadEvent(&pHeader);
+                if (!pHeader)
+                {
+                    if (err != 0)
+                    {
+                        WriteWarningMessage(inputPath, err, "input.Read failed, ignoring rest of input");
+                    }
+                    break;
+                }
+
+                uint32_t eventDataSize;
+                switch (pHeader->type)
+                {
+                default:
+                    eventDataSize = pHeader->size;
+                    break;
+
+                case PERF_RECORD_AUXTRACE:
+                    // Special-case. Event content size != pHeader->size.
+                    eventDataSize = input.EventDataSize(pHeader);
+                    break;
+
+                case PERF_RECORD_HEADER_ATTR:
+                    // Pseudo-event, conflicts with AddEventDesc.
+                    // PerfDataFile automatically merges data from this event into its own
+                    // EventDesc table. We'll use AddEventDesc to generate the output file's
+                    // attr headers based on the merged EventDesc table.
+                    continue;
+
+                case PERF_RECORD_HEADER_EVENT_TYPE:
+                    // Pseudo-event, conflicts with AddEventDesc.
+                    // PerfDataFile could automatically merge data from this event into its
+                    // own EventDesc table, but that is not implemented because this event
+                    // type is deprecated. Instead, we'll just ignore this event type.
+                    continue;
+
+                case PERF_RECORD_HEADER_TRACING_DATA:
+                    // Pseudo-event, conflicts with SetTracingData.
+                    // PerfDataFile automatically merges data from this event into its own
+                    // metadata table. We'll use SetTracingData to generate the output file's
+                    // metadata based on the metadata referenced by the input file's events.
+                    continue;
+
+                case PERF_RECORD_HEADER_BUILD_ID:
+                case PERF_RECORD_HEADER_FEATURE:
+                    // Pseudo-events, conflict with SetHeader.
+                    // PerfDataFile automatically merges data from these events into its own
+                    // header table. We'll use SetHeader to generate the output file's headers
+                    // based on the merged header table.
+                    continue;
+                }
+
+                if (pHeader->type == PERF_RECORD_SAMPLE)
+                {
+                    // Populate the output file's metadata from the event's metadata.
+                    PerfSampleEventInfo info;
+                    err = input.GetSampleEventInfo(pHeader, &info);
+                    if (err != 0)
+                    {
+                        WriteWarningMessage(inputPath, err, "input.GetSampleEventInfo failed, metadata may be incomplete");
+                    }
+                    else if (info.event_desc->metadata)
+                    {
+                        auto const& desc = *info.event_desc;
+                        err = output.AddTracepointEventDesc(desc);
+                        if (err == 0)
+                        {
+                            // We don't need to AddEventDesc for the IDs covered by this event_desc.
+                            for (auto i = 0u; i != desc.ids_count; i += 1)
+                            {
+                                sampleIdsUsed.insert(desc.ids[i]);
+                            }
+                        }
+                        else if (err != EEXIST)
+                        {
+                            WriteWarningMessage(outputPath, err, "output.AddTracingData failed, metadata may be incomplete");
+                        }
+                    }
+                }
+
+                err = output.WriteEventData(pHeader, eventDataSize);
+                if (err != 0)
+                {
+                    WriteErrorMessage(outputPath, err, "output.Write failed");
+                    goto CloseAndUnlinkOutput;
+                }
+            }
+
+            // Populate the output file's EventDesc table from the input file's table.
+            // Some of this was already done by AddTracingData.
+            // In addition, the input file's table usually has duplicate entries - one entry with
+            // names and one entry without names. Therefore, MergeEventDesc will skip ids that are
+            // already populated, and we merge descriptors with names before merging descriptors
+            // without names.
+            for (size_t iDesc = 0; iDesc != input.EventDescCount(); iDesc += 1)
+            {
+                // First, merge data from descriptors that have names.
+                auto const desc = input.EventDesc(iDesc);
+                if (desc.name[0] != '\0')
+                {
+                    MergeEventDesc(output, outputPath, sampleIdsUsed, sampleIdsBuffer, desc);
+                }
+            }
+            for (size_t iDesc = 0; iDesc != input.EventDescCount(); iDesc += 1)
+            {
+                // Second, fill gaps (if any) using descriptors that don't have names.
+                auto const desc = input.EventDesc(iDesc);
+                if (desc.name[0] == '\0')
+                {
+                    MergeEventDesc(output, outputPath, sampleIdsUsed, sampleIdsBuffer, desc);
+                }
+            }
+
+            // Populate the output file's headers.
+            for (auto i = PERF_HEADER_FIRST_FEATURE; i != PERF_HEADER_LAST_FEATURE; i = static_cast<PerfHeaderIndex>(i + 1))
+            {
+                switch (i)
+                {
+                case PERF_HEADER_TRACING_DATA:
+                case PERF_HEADER_EVENT_DESC:
+                    // Let the output file auto-populate these based on AddEventDesc and AddTracingData.
+                    continue;
+                default:
+                    break;
+                }
+
+                auto header = input.Header(i);
+                if (!header.empty())
+                {
+                    // Copy the input file's merged header into the output file.
+                    err = output.SetHeader(i, header.data(), static_cast<unsigned>(header.size()));
+                    if (err != 0)
+                    {
+                        WriteErrorMessage(outputPath, err, "output.SetHeader failed, closing");
+                        goto CloseAndUnlinkOutput;
+                    }
+                }
+            }
+
+            err = output.SetTracingData(
+                input.TracingDataLongSize(),
+                input.TracingDataPageSize(),
+                input.TracingDataHeaderPage(),
+                input.TracingDataHeaderEvent(),
+                input.TracingDataFtraces(),
+                input.TracingDataFtraceCount(),
+                input.TracingDataKallsyms(),
+                input.TracingDataPrintk(),
+                input.TracingDataSavedCmdLine());
+            if (err != 0)
+            {
+                WriteErrorMessage(outputPath, err, "output.SetTracingData failed");
+                goto CloseAndUnlinkOutput;
+            }
+
+            err = output.FinalizeAndClose();
+            if (err != 0)
+            {
+                WriteErrorMessage(outputPath, err, "output.FinalizeAndClose failed");
+                goto CloseAndUnlinkOutput;
+            }
+
+            fprintf(stdout, "\"%s\" --> \"%s\"\n", inputPath, outputPath);
+            mainSuccessful = true; // One or more files completed.
+            continue;
+
+        CloseAndUnlinkOutput:
+
+            output.CloseNoFinalize();
+            UNLINK(outputPath);
+        }
+    }
+    catch (std::exception const& ex)
+    {
+        fprintf(stderr, "\nException: %s\n", ex.what());
+        mainSuccessful = false;
+    }
+
+    return mainSuccessful ? 0 : 1;
+}

--- a/libtracepoint-decode-cpp/samples/perf-file-rewrite.cpp
+++ b/libtracepoint-decode-cpp/samples/perf-file-rewrite.cpp
@@ -232,9 +232,13 @@ main(int argc, char* argv[])
                                 sampleIdsUsed.insert(desc.ids[i]);
                             }
                         }
-                        else if (err != EEXIST)
+                        else if (err == EEXIST)
                         {
-                            WriteWarningMessage(outputPath, err, "output.AddTracingData failed, metadata may be incomplete");
+                            // Already added metadata for this event.
+                        }
+                        else
+                        {
+                            WriteWarningMessage(outputPath, err, "output.AddTracepointEventDesc failed, metadata may be incomplete");
                         }
                     }
                 }
@@ -248,11 +252,11 @@ main(int argc, char* argv[])
             }
 
             // Populate the output file's EventDesc table from the input file's table.
-            // Some of this was already done by AddTracingData.
+            // Some of this was already done by AddTracepointEventDesc.
             // In addition, the input file's table usually has duplicate entries - one entry with
             // names and one entry without names. Therefore, MergeEventDesc will skip ids that are
-            // already populated, and we merge descriptors with names before merging descriptors
-            // without names.
+            // already populated, and we merge all descriptors with names before merging any
+            // descriptors that don't have names.
             for (size_t iDesc = 0; iDesc != input.EventDescCount(); iDesc += 1)
             {
                 // First, merge data from descriptors that have names.

--- a/libtracepoint-decode-cpp/src/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/src/CMakeLists.txt
@@ -2,7 +2,9 @@
 add_library(tracepoint-decode
     PerfByteReader.cpp
     PerfDataFile.cpp
+    PerfDataFileWriter.cpp
     PerfEventAbi.cpp
+    PerfEventInfo.cpp
     PerfEventMetadata.cpp
     PerfEventSessionInfo.cpp)
 target_include_directories(tracepoint-decode
@@ -12,6 +14,8 @@ target_include_directories(tracepoint-decode
 set(DECODE_HEADERS
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfByteReader.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfDataFile.h"
+    "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfDataFileDefs.h"
+    "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfDataFileWriter.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventAbi.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventInfo.h"
     "${PROJECT_SOURCE_DIR}/include/tracepoint/PerfEventMetadata.h"

--- a/libtracepoint-decode-cpp/src/PerfDataFile.cpp
+++ b/libtracepoint-decode-cpp/src/PerfDataFile.cpp
@@ -279,6 +279,7 @@ PerfDataFile::Close() noexcept
     }
 
     m_eventDescList.clear();
+    m_eventDescById.clear();
     m_byteReader = PerfByteReader();
     m_sampleIdOffset = -1;
     m_nonSampleIdOffset = -1;

--- a/libtracepoint-decode-cpp/src/PerfDataFileWriter.cpp
+++ b/libtracepoint-decode-cpp/src/PerfDataFileWriter.cpp
@@ -1,0 +1,831 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <tracepoint/PerfDataFileWriter.h>
+#include <tracepoint/PerfEventAbi.h>
+#include <tracepoint/PerfEventMetadata.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>  // _O_BINARY
+
+#ifdef _WIN32
+#include <io.h>
+static bool constexpr HostIsBigEndian = false;
+#define CLOSE(file)                     _close(file)
+#define LSEEK64(file, offset, origin)   _lseeki64(file, offset, origin)
+#define WRITE(file, data, size)         _write(file, data, size)
+#define WRITE_SIZE(size)                static_cast<unsigned>(std::min<size_t>(0x80000000, size))
+#define GETPAGESIZE()                   4096 // PAGE_SIZE
+#define O_CLOEXEC                       0
+#else // _WIN32
+#include <unistd.h>
+#include <sys/uio.h>
+#include <endian.h>
+static bool constexpr HostIsBigEndian = __BYTE_ORDER == __BIG_ENDIAN;
+#define CLOSE(file)                     close(file)
+#define LSEEK64(file, offset, origin)   lseek64(file, offset, origin)
+#define WRITE(file, data, size)         write(file, data, size)
+#define WRITE_SIZE(size)                (size)
+#define GETPAGESIZE()                   sysconf(_SC_PAGESIZE)
+#endif // _WIN32
+
+#ifndef _Inout_
+#define _Inout_
+#endif
+
+using namespace tracepoint_decode;
+
+static constexpr auto InvalidFilePos = static_cast<uint64_t>(-1);
+static constexpr char Zero64[8] = {};
+
+_Success_(return == 0) static int
+open_s(_Out_ int* pFile, _In_z_ char const* path, int oflags, int pmode)
+{
+#ifdef _WIN32
+    return _sopen_s(pFile, path, oflags | _O_BINARY, _SH_DENYRW, pmode & (_S_IREAD | _S_IWRITE));
+#else
+    auto const file = open(path, oflags, pmode);
+    *pFile = file;
+    return file < 0 ? errno : 0;
+#endif
+}
+
+template<class T>
+static void
+AppendValue(_Inout_ std::vector<char>* pHeader, T const& value)
+{
+    auto const pbValue = reinterpret_cast<char const*>(&value);
+    pHeader->insert(pHeader->end(), pbValue, pbValue + sizeof(T));
+}
+
+static void
+AppendString(_Inout_ std::vector<char>* pHeader, std::string_view value)
+{
+    pHeader->insert(pHeader->end(), value.data(), value.data() + value.size());
+}
+
+static void
+AppendStringZ(_Inout_ std::vector<char>* pHeader, std::string_view value)
+{
+    AppendString(pHeader, value);
+    pHeader->push_back(0);
+}
+
+static void
+AppendSection32(
+    _Inout_ std::vector<char>* pHeader,
+    _In_reads_bytes_(cb) char const* pb,
+    uint32_t cb)
+{
+    AppendValue<uint32_t>(pHeader, cb);
+    pHeader->insert(pHeader->end(), pb, pb + cb);
+}
+
+static void
+AppendSection64(
+    _Inout_ std::vector<char>* pHeader,
+    _In_reads_bytes_(cb) char const* pb,
+    size_t cb)
+{
+    AppendValue<uint64_t>(pHeader, cb);
+    pHeader->insert(pHeader->end(), pb, pb + cb);
+}
+
+static void
+AppendNamedSection64(
+    _Inout_ std::vector<char>* pHeader,
+    std::string_view name,
+    std::string_view defaultValue,
+    std::vector<char> const& setValue)
+{
+    auto value = setValue.data() == nullptr
+        ? defaultValue
+        : std::string_view(setValue.data(), setValue.size());
+    AppendStringZ(pHeader, name);
+    AppendSection64(pHeader, value.data(), value.size());
+}
+
+// From: perf.data-file-format.txt
+struct PerfDataFileWriter::perf_file_section {
+    uint64_t offset; // offset from start of file
+    uint64_t size;   // size of the section
+};
+
+struct PerfDataFileWriter::perf_file_header
+{
+    static constexpr uint64_t Magic2 = 0x32454C4946524550; // "PERFILE2"
+
+    uint64_t magic; // If correctly byte-swapped, this will be equal to Magic2.
+    uint64_t size;  // size of the header
+    uint64_t attr_size; // size of an attribute in attrs
+    perf_file_section attrs;
+    perf_file_section data;
+    perf_file_section event_types; // Not used - superceded by PERF_HEADER_TRACING_DATA.
+
+    // 256-bit bitmap based on HEADER_BITS
+    uint64_t flags[4];
+};
+
+struct PerfDataFileWriter::EventDesc
+{
+    static uint32_t const NameMaxSize = 65535u;
+    static uint32_t const SampleIdsMaxSize = 0xFFFFFFFF;
+
+    std::vector<char> name; // does not include nul-termination, max size is NameMaxSize.
+    std::vector<uint64_t> sampleIds; // max size is SampleIdsMaxSize.
+    perf_event_attr attr;
+
+    EventDesc(PerfEventDesc const& desc, uint32_t nameLen)
+        : name(desc.name, desc.name + nameLen)
+        , sampleIds(desc.ids, desc.ids + desc.ids_count)
+    {
+        if (sizeof(attr) <= desc.attr->size)
+        {
+            memcpy(&attr, desc.attr, sizeof(attr));
+            attr.size = static_cast<perf_event_attr_size>(sizeof(attr));
+        }
+        else
+        {
+            memset(&attr, 0, sizeof(attr));
+            memcpy(&attr, desc.attr, desc.attr->size);
+        }
+    }
+};
+
+struct PerfDataFileWriter::TracepointInfo
+{
+    PerfEventMetadata const& metadata;
+    size_t eventDescIndex;
+
+    TracepointInfo(PerfEventMetadata const& _metadata, size_t index)
+        : metadata(_metadata)
+        , eventDescIndex(index)
+    {
+        return;
+    }
+};
+
+PerfDataFileWriter::~PerfDataFileWriter()
+{
+    CloseNoFinalize();
+}
+
+PerfDataFileWriter::PerfDataFileWriter() noexcept(false)
+    : m_filePos(InvalidFilePos)
+    , m_file(-1)
+    , m_eventDescs()
+    , m_tracepointInfoByCommonType()
+    , m_headers()
+    , m_tracingDataPageSize(0)
+    , m_tracingDataLongSize(sizeof(size_t))
+{
+    return;
+}
+
+void
+PerfDataFileWriter::CloseNoFinalize() noexcept
+{
+    assert(ValidFilePos());
+    if (m_file >= 0)
+    {
+        CLOSE(m_file);
+    }
+
+    m_file = -1;
+    m_filePos = InvalidFilePos;
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::FinalizeAndClose() noexcept
+{
+    int error = 0;
+
+    try
+    {
+        if (m_headers[PERF_HEADER_TRACING_DATA].empty())
+        {
+            SynthesizeTracingData();
+        }
+
+        if (m_headers[PERF_HEADER_EVENT_DESC].empty())
+        {
+            SynthesizeEventDesc();
+        }
+
+        perf_file_header fileHeader = {};
+        fileHeader.magic = perf_file_header::Magic2;
+        fileHeader.size = sizeof(perf_file_header);
+        fileHeader.attr_size = sizeof(perf_event_attr) + sizeof(perf_file_section);
+
+        // Current implementation starts the data section immediately after the file header.
+        // It ends wherever we are now.
+        fileHeader.data.offset = sizeof(perf_file_header);
+        fileHeader.data.size = m_filePos - sizeof(perf_file_header);
+
+        // The sections for the perf headers must go immediately after the data section.
+        // Current implementation puts the data for the perf headers right after that.
+        error = WriteHeaders(&fileHeader.flags[0]);
+        if (error != 0)
+        {
+            goto Done;
+        }
+
+        // The attr section contains a sequence of attr+idSection blocks.
+        // Current implementation puts the id data right after that.
+        error = WriteAttrs(&fileHeader.attrs);
+        if (error != 0)
+        {
+            goto Done;
+        }
+
+        // Finalize the file header.
+
+        assert(ValidFilePos());
+
+        auto const seekResult = LSEEK64(m_file, 0, SEEK_SET);
+        m_filePos = 0;
+        if (seekResult != 0)
+        {
+            error = seekResult < 0 ? errno : EDOM;
+            goto Done;
+        }
+
+        error = WriteData(&fileHeader, sizeof(fileHeader));
+    }
+    catch (...)
+    {
+        error = ENOMEM;
+    }
+
+Done:
+
+    CloseNoFinalize();
+    return error;
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::Create(_In_z_ char const* filePath, int mode) noexcept
+{
+    int error;
+
+    CloseNoFinalize();
+    m_eventDescs.clear();
+    m_tracepointInfoByCommonType.clear();
+    for (auto& header : m_headers)
+    {
+        header.clear();
+    }
+
+    error = open_s(&m_file, filePath, O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, mode);
+    if (m_file < 0)
+    {
+        error = errno;
+    }
+    else
+    {
+        m_filePos = 0;
+        static constexpr perf_file_header zeroHeader = {};
+        error = WriteData(&zeroHeader, sizeof(zeroHeader));
+        if (error != 0)
+        {
+            CloseNoFinalize();
+        }
+    }
+
+    return error;
+}
+
+uint64_t
+PerfDataFileWriter::FilePos() const noexcept
+{
+    assert(ValidFilePos());
+    return m_filePos;
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::WriteEventData(
+    _In_reads_bytes_(dataSize) void const* data,
+    size_t dataSize) noexcept
+{
+    int error = WriteData(data, dataSize);
+    return error;
+}
+
+#ifndef _WIN32
+
+_Success_(return >= 0) ptrdiff_t
+PerfDataFileWriter::WriteEventDataIovecs(
+    _In_reads_(iovecsCount) struct iovec const* iovecs,
+    int iovecsCount) noexcept
+{
+    auto const writeResult = writev(m_file, iovecs, iovecsCount);
+    if (writeResult >= 0)
+    {
+        m_filePos += writeResult;
+    }
+
+    return writeResult;
+}
+
+#endif // !_WIN32
+
+size_t
+PerfDataFileWriter::GetHeaderSize(PerfHeaderIndex index) const noexcept
+{
+    return index >= PERF_HEADER_LAST_FEATURE
+        ? 0u
+        : m_headers[index].size();
+}
+
+void const*
+PerfDataFileWriter::GetHeaderData(PerfHeaderIndex index) const noexcept
+{
+    return index >= PERF_HEADER_LAST_FEATURE
+        ? 0
+        : m_headers[index].data();
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::SetHeader(
+    PerfHeaderIndex index,
+    _In_reads_bytes_(dataSize) void const* data,
+    size_t dataSize) noexcept
+{
+    int error;
+
+    try
+    {
+        if (index >= PERF_HEADER_LAST_FEATURE)
+        {
+            error = EINVAL;
+        }
+        else
+        {
+            auto const pData = static_cast<char const*>(data);
+            m_headers[index].assign(&pData[0], &pData[dataSize]);
+            error = 0;
+        }
+    }
+    catch (...)
+    {
+        error = ENOMEM;
+    }
+
+    return error;
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::SetTracingData(
+    uint8_t longSize,
+    uint32_t pageSize,
+    std::string_view headerPage,
+    std::string_view headerEvent,
+    _In_reads_(ftraceCount) std::string_view const* ftraces,
+    uint32_t ftraceCount,
+    std::string_view kallsyms,
+    std::string_view printk,
+    std::string_view savedCmdLine) noexcept
+{
+    int error;
+
+    if (kallsyms.size() > 0x80000000 ||
+        printk.size() > 0x80000000)
+    {
+        error = E2BIG;
+    }
+    else try
+    {
+        if (longSize != 0)
+        {
+            m_tracingDataLongSize = longSize;
+        }
+
+        if (pageSize != 0)
+        {
+            m_tracingDataPageSize = pageSize;
+        }
+
+        if (headerPage.data())
+        {
+            m_tracingDataHeaderPage.assign(headerPage.data(), headerPage.data() + headerPage.size());
+        }
+
+        if (headerEvent.data())
+        {
+            m_tracingDataHeaderEvent.assign(headerEvent.data(), headerEvent.data() + headerEvent.size());
+        }
+
+        if (ftraces)
+        {
+            m_tracingDataFtraces.clear();
+            m_tracingDataFtraces.reserve(ftraceCount);
+            for (uint32_t i = 0; i != ftraceCount; i += 1)
+            {
+                auto ftrace = ftraces[i];
+                m_tracingDataFtraces.emplace_back(ftrace.data(), ftrace.data() + ftrace.size());
+            }
+        }
+
+        if (kallsyms.data())
+        {
+            m_tracingDataKallsyms.assign(kallsyms.data(), kallsyms.data() + kallsyms.size());
+        }
+
+        if (printk.data())
+        {
+            m_tracingDataPrintk.assign(printk.data(), printk.data() + printk.size());
+        }
+
+        if (savedCmdLine.data())
+        {
+            m_tracingDataSavedCmdline.assign(savedCmdLine.data(), savedCmdLine.data() + savedCmdLine.size());
+        }
+
+        error = 0;
+    }
+    catch (...)
+    {
+        error = ENOMEM;
+    }
+
+    return 0;
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::AddEventDesc(PerfEventDesc const& desc) noexcept
+{
+    int error;
+
+    assert(desc.attr != nullptr); // Precondition
+    assert(desc.name != nullptr); // Precondition
+    if (m_eventDescs.size() == 0xFFFFFFFF)
+    {
+        error = E2BIG;
+    }
+    else try
+    {
+        auto const nameLen = strlen(desc.name);
+        if (nameLen > EventDesc::NameMaxSize)
+        {
+            error = E2BIG;
+        }
+        else
+        {
+            m_eventDescs.emplace_back(desc, static_cast<uint32_t>(nameLen));
+            error = 0;
+        }
+    }
+    catch (...)
+    {
+        error = ENOMEM;
+    }
+
+    return error;
+}
+
+bool
+PerfDataFileWriter::HasTracepointEventDesc(uint32_t common_type) const noexcept
+{
+    return 0 != m_tracepointInfoByCommonType.count(common_type);
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::AddTracepointEventDesc(PerfEventDesc const& desc) noexcept
+{
+    int error;
+
+    assert(desc.attr != nullptr); // Precondition
+    assert(desc.name != nullptr); // Precondition
+    assert(desc.metadata != nullptr); // Precondition
+    try
+    {
+        auto [it, inserted] = m_tracepointInfoByCommonType.try_emplace(
+            desc.metadata->Id(),
+            *desc.metadata,
+            m_eventDescs.size());
+        if (!inserted)
+        {
+            error = EEXIST;
+        }
+        else
+        {
+            // Added new metadata so add new EventDesc too.
+            error = AddEventDesc(desc);
+            if (error != 0)
+            {
+                m_tracepointInfoByCommonType.erase(it);
+            }
+        }
+    }
+    catch (...)
+    {
+        error = ENOMEM;
+    }
+
+    return error;
+}
+
+bool
+PerfDataFileWriter::ValidFilePos() const noexcept
+{
+    if (m_file < 0)
+    {
+        // File is closed, m_filePos should be -1.
+        return m_filePos == InvalidFilePos;
+    }
+
+    auto const seekResult = LSEEK64(m_file, 0, SEEK_CUR);
+    if (seekResult < 0)
+    {
+        // File is in error condition, m_filePos is unknown.
+        return true;
+    }
+
+    return m_filePos == static_cast<uint64_t>(seekResult);
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::WriteData(
+    _In_reads_bytes_(dataSize) void const* data,
+    size_t dataSize) noexcept
+{
+    int error = 0;
+
+    for (size_t i = 0; i < dataSize;)
+    {
+        auto const writeSize = WRITE_SIZE(dataSize - i);
+        auto const writeResult = WRITE(
+            m_file,
+            static_cast<char const*>(data) + i,
+            writeSize);
+        if (writeResult < 0)
+        {
+            error = errno;
+            break;
+        }
+
+        m_filePos += writeResult;
+        i += writeResult;
+    }
+
+    return error;
+}
+
+void
+PerfDataFileWriter::SynthesizeTracingData()
+{
+    using namespace std::string_view_literals;
+
+    static constexpr auto DefaultHeaderPage = 
+        "\tfield: u64 timestamp;\toffset:0;\tsize:8;\tsigned:0;\n"
+        "\tfield: local_t commit;\toffset:8;\tsize:8;\tsigned:1;\n"
+        "\tfield: int overwrite;\toffset:8;\tsize:1;\tsigned:1;\n"
+        "\tfield: char data;\toffset:16;\tsize:4080;\tsigned:0;\n"
+        ""sv;
+    static constexpr auto DefaultHeaderEvent =
+        "# compressed entry header\n"
+        "\ttype_len    :    5 bits\n"
+        "\ttime_delta  :   27 bits\n"
+        "\tarray       :   32 bits\n"
+        "\n"
+        "\tpadding     : type == 29\n"
+        "\ttime_extend : type == 30\n"
+        "\ttime_stamp : type == 31\n"
+        "\tdata max type_len  == 28\n"
+        ""sv;
+
+    auto& header = m_headers[PERF_HEADER_TRACING_DATA];
+    header.clear();
+
+    if (m_tracingDataPageSize == 0)
+    {
+        m_tracingDataPageSize = GETPAGESIZE();
+    }
+
+    AppendStringZ(&header, "\x17\x08\x44tracing0.6"sv);
+    AppendValue<uint8_t>(&header, HostIsBigEndian);
+    AppendValue<uint8_t>(&header, m_tracingDataLongSize);
+    AppendValue<uint32_t>(&header, m_tracingDataPageSize);
+    AppendNamedSection64(&header, "header_page"sv, DefaultHeaderPage, m_tracingDataHeaderPage);
+    AppendNamedSection64(&header, "header_event"sv, DefaultHeaderEvent, m_tracingDataHeaderEvent);
+
+    // ftraces
+    assert(m_tracingDataFtraces.size() <= 0xFFFFFFFF);
+    AppendValue<uint32_t>(&header, static_cast<uint32_t>(m_tracingDataFtraces.size()));
+    for (auto const& ftrace : m_tracingDataFtraces)
+    {
+        AppendSection64(&header, ftrace.data(), ftrace.size());
+    }
+
+    // systems (and events)
+
+    // Group events by system.
+    using InfoIt = decltype(m_tracepointInfoByCommonType.cbegin());
+    std::map<std::string_view, std::vector<InfoIt>> commonTypesBySystem;
+    for (auto it = m_tracepointInfoByCommonType.cbegin(); it != m_tracepointInfoByCommonType.cend(); ++it)
+    {
+        auto const& meta = it->second.metadata;
+        commonTypesBySystem[meta.SystemName()].push_back(it);
+    }
+
+    // SystemCount
+    AppendValue<uint32_t>(
+        &header,
+        static_cast<uint32_t>(commonTypesBySystem.size()));
+
+    // Systems
+    for (auto& ctbs : commonTypesBySystem)
+    {
+        // SystemName
+        AppendStringZ(&header, ctbs.first);
+
+        // EventCount
+        AppendValue<uint32_t>(&header, static_cast<uint32_t>(ctbs.second.size()));
+
+        // Events
+        for (auto it : ctbs.second)
+        {
+            auto const& meta = it->second.metadata;
+            auto const format = meta.FormatFileContents();
+            AppendSection64(&header, format.data(), format.size());
+        }
+    }
+
+    // Other stuff.
+    AppendSection32(
+        &header,
+        m_tracingDataKallsyms.data(),
+        static_cast<uint32_t>(m_tracingDataKallsyms.size()));
+    AppendSection32(
+        &header,
+        m_tracingDataPrintk.data(),
+        static_cast<uint32_t>(m_tracingDataPrintk.size()));
+    AppendSection64(
+        &header,
+        m_tracingDataSavedCmdline.data(),
+        m_tracingDataSavedCmdline.size());
+}
+
+void
+PerfDataFileWriter::SynthesizeEventDesc()
+{
+    auto& header = m_headers[PERF_HEADER_EVENT_DESC];
+    header.clear();
+
+    /*
+    From perf.data-file-format.txt:
+    struct {
+           uint32_t nr; // number of events
+           uint32_t attr_size; //size of each perf_event_attr
+           struct {
+	          struct perf_event_attr attr; // size of attr_size
+	          uint32_t nr_ids;
+	          struct perf_header_string event_string;
+	          uint64_t ids[nr_ids];
+           } events[nr]; // Variable length records
+    };
+    */
+
+    assert(m_eventDescs.size() <= 0xFFFFFFFF);
+    auto const nr = static_cast<uint32_t>(m_eventDescs.size());
+
+    AppendValue<uint32_t>(&header, nr);                         // nr
+    AppendValue<uint32_t>(&header, sizeof(perf_event_attr));    // attr_size
+    for (auto& desc : m_eventDescs)                             // events
+    {
+        auto const name = desc.name.data();
+
+        static_assert(EventDesc::NameMaxSize < static_cast<uint32_t>(EventDesc::NameMaxSize + 8u),
+            "Bad NameMaxSize (nameSize + namePad can overflow)");
+        assert(desc.name.size() <= EventDesc::NameMaxSize);
+        auto const nameSize = static_cast<uint32_t>(desc.name.size());
+        auto const namePad = 8u - (nameSize & 7); // 1 to 8 bytes of '\0'.
+
+        assert(desc.sampleIds.size() <= EventDesc::SampleIdsMaxSize);
+        auto const nr_ids = static_cast<uint32_t>(desc.sampleIds.size());
+
+        AppendValue<perf_event_attr>(&header, desc.attr);       // attr
+        AppendValue<uint32_t>(&header, nr_ids);                 // nr_ids
+        AppendValue<uint32_t>(&header, nameSize + namePad);     // event_string.len
+        header.insert(header.end(), &name[0], &name[nameSize]);// event_string.string
+        header.insert(header.end(), &Zero64[0], &Zero64[namePad]);// NUL + pad to x8
+        header.insert(                                        // ids
+            header.end(),
+            reinterpret_cast<char const*>(desc.sampleIds.data()),
+            reinterpret_cast<char const*>(desc.sampleIds.data() + desc.sampleIds.size()));
+    }
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::WriteHeaders(_Out_ uint64_t* pFlags0) noexcept
+{
+    int error = 0;
+    uint64_t flags0 = 0;
+
+    // Update the flags and compute where the first perf header will go.
+    auto firstPerfHeaderOffset = m_filePos;
+    for (uint32_t i = 0; i < PERF_HEADER_LAST_FEATURE; i += 1)
+    {
+        auto const& header = m_headers[i];
+        if (!header.empty())
+        {
+            flags0 |= static_cast<uint64_t>(1) << i;
+            firstPerfHeaderOffset += sizeof(perf_file_section);
+        }
+    }
+
+    // Store perf_file_section for each perf header.
+    auto perfHeaderOffset = firstPerfHeaderOffset;
+    for (uint32_t i = 0; i < PERF_HEADER_LAST_FEATURE; i += 1)
+    {
+        auto& header = m_headers[i];
+        if (!header.empty())
+        {
+            auto headerSize = header.size();
+
+            perf_file_section headerSection = {};
+            headerSection.offset = perfHeaderOffset;
+            headerSection.size = headerSize;
+            perfHeaderOffset += headerSize;
+
+            error = WriteData(&headerSection, sizeof(headerSection));
+            if (error != 0)
+            {
+                goto Done;
+            }
+        }
+    }
+
+    // Store data for each perf header that is present.
+    for (uint32_t i = 0; i < PERF_HEADER_LAST_FEATURE; i += 1)
+    {
+        auto const& header = m_headers[i];
+        if (!header.empty())
+        {
+            error = WriteData(header.data(), header.size());
+            if (error != 0)
+            {
+                goto Done;
+            }
+        }
+    }
+
+    assert(m_filePos == perfHeaderOffset);
+
+Done:
+
+    *pFlags0 = flags0;
+    return error;
+}
+
+_Success_(return == 0) int
+PerfDataFileWriter::WriteAttrs(_Out_ perf_file_section* pAttrsSection) noexcept
+{
+    int error = 0;
+
+    uint64_t const PerfAttrEntrySize = sizeof(perf_event_attr) + sizeof(perf_file_section);
+    auto const perfAttrSectionSize = PerfAttrEntrySize * m_eventDescs.size();
+    pAttrsSection->offset = m_filePos;
+    pAttrsSection->size = perfAttrSectionSize;
+
+    auto const firstAttrIdsOffset = m_filePos + perfAttrSectionSize;
+    auto attrIdsOffset = firstAttrIdsOffset;
+
+    for (auto const& desc : m_eventDescs)
+    {
+        error = WriteData(&desc.attr, sizeof(perf_event_attr));
+        if (error != 0)
+        {
+            goto Done;
+        }
+
+        perf_file_section idsSection = {};
+        idsSection.offset = attrIdsOffset;
+        idsSection.size = desc.sampleIds.size() * sizeof(desc.sampleIds[0]);
+        attrIdsOffset += idsSection.size;
+
+        error = WriteData(&idsSection, sizeof(idsSection));
+        if (error != 0)
+        {
+            goto Done;
+        }
+    }
+
+    for (auto const& desc : m_eventDescs)
+    {
+        error = WriteData(
+            desc.sampleIds.data(),
+            desc.sampleIds.size() * sizeof(desc.sampleIds[0]));
+        if (error != 0)
+        {
+            goto Done;
+        }
+    }
+
+Done:
+
+    return error;
+}

--- a/libtracepoint-decode-cpp/src/PerfDataFileWriter.cpp
+++ b/libtracepoint-decode-cpp/src/PerfDataFileWriter.cpp
@@ -62,15 +62,9 @@ AppendValue(_Inout_ std::vector<char>* pHeader, T const& value)
 }
 
 static void
-AppendString(_Inout_ std::vector<char>* pHeader, std::string_view value)
-{
-    pHeader->insert(pHeader->end(), value.data(), value.data() + value.size());
-}
-
-static void
 AppendStringZ(_Inout_ std::vector<char>* pHeader, std::string_view value)
 {
-    AppendString(pHeader, value);
+    pHeader->insert(pHeader->end(), value.data(), value.data() + value.size());
     pHeader->push_back(0);
 }
 
@@ -160,9 +154,9 @@ struct PerfDataFileWriter::TracepointInfo
     PerfEventMetadata const& metadata;
     size_t eventDescIndex;
 
-    TracepointInfo(PerfEventMetadata const& _metadata, size_t index)
+    TracepointInfo(PerfEventMetadata const& _metadata, size_t _eventDescIndex)
         : metadata(_metadata)
-        , eventDescIndex(index)
+        , eventDescIndex(_eventDescIndex)
     {
         return;
     }
@@ -451,7 +445,7 @@ PerfDataFileWriter::SetTracingData(
         error = ENOMEM;
     }
 
-    return 0;
+    return error;
 }
 
 _Success_(return == 0) int
@@ -710,9 +704,9 @@ PerfDataFileWriter::SynthesizeEventDesc()
         AppendValue<perf_event_attr>(&header, desc.attr);       // attr
         AppendValue<uint32_t>(&header, nr_ids);                 // nr_ids
         AppendValue<uint32_t>(&header, nameSize + namePad);     // event_string.len
-        header.insert(header.end(), &name[0], &name[nameSize]);// event_string.string
+        header.insert(header.end(), &name[0], &name[nameSize]); // event_string.string
         header.insert(header.end(), &Zero64[0], &Zero64[namePad]);// NUL + pad to x8
-        header.insert(                                        // ids
+        header.insert(                                          // ids
             header.end(),
             reinterpret_cast<char const*>(desc.sampleIds.data()),
             reinterpret_cast<char const*>(desc.sampleIds.data() + desc.sampleIds.size()));

--- a/libtracepoint-decode-cpp/src/PerfEventInfo.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventInfo.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <tracepoint/PerfEventInfo.h>
+#include <tracepoint/PerfEventAbi.h>
+#include <tracepoint/PerfDataFileDefs.h>
+#include <assert.h>
+
+using namespace tracepoint_decode;
+
+perf_event_attr const&
+PerfSampleEventInfo::Attr() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return *event_desc->attr;
+}
+
+_Ret_z_ char const*
+PerfSampleEventInfo::Name() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return event_desc->name;
+}
+
+uint64_t
+PerfSampleEventInfo::SampleType() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return event_desc->attr->sample_type;
+}
+
+_Ret_opt_ PerfEventMetadata const*
+PerfSampleEventInfo::Metadata() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return event_desc->metadata;
+}
+
+perf_event_attr const&
+PerfNonSampleEventInfo::Attr() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return *event_desc->attr;
+}
+
+_Ret_z_ char const*
+PerfNonSampleEventInfo::Name() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return event_desc->name;
+}
+
+uint64_t
+PerfNonSampleEventInfo::SampleType() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return event_desc->attr->sample_type;
+}

--- a/libtracepoint-decode-cpp/src/PerfEventInfo.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventInfo.cpp
@@ -8,6 +8,13 @@
 
 using namespace tracepoint_decode;
 
+uint64_t
+PerfSampleEventInfo::SampleType() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    return event_desc->attr->sample_type;
+}
+
 perf_event_attr const&
 PerfSampleEventInfo::Attr() const noexcept
 {
@@ -22,13 +29,6 @@ PerfSampleEventInfo::Name() const noexcept
     return event_desc->name;
 }
 
-uint64_t
-PerfSampleEventInfo::SampleType() const noexcept
-{
-    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
-    return event_desc->attr->sample_type;
-}
-
 _Ret_opt_ PerfEventMetadata const*
 PerfSampleEventInfo::Metadata() const noexcept
 {
@@ -36,23 +36,23 @@ PerfSampleEventInfo::Metadata() const noexcept
     return event_desc->metadata;
 }
 
+uint64_t
+PerfNonSampleEventInfo::SampleType() const noexcept
+{
+    assert(event_desc->attr); // Requires: GetNonSampleEventInfo() succeeded.
+    return event_desc->attr->sample_type;
+}
+
 perf_event_attr const&
 PerfNonSampleEventInfo::Attr() const noexcept
 {
-    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    assert(event_desc->attr); // Requires: GetNonSampleEventInfo() succeeded.
     return *event_desc->attr;
 }
 
 _Ret_z_ char const*
 PerfNonSampleEventInfo::Name() const noexcept
 {
-    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
+    assert(event_desc->attr); // Requires: GetNonSampleEventInfo() succeeded.
     return event_desc->name;
-}
-
-uint64_t
-PerfNonSampleEventInfo::SampleType() const noexcept
-{
-    assert(event_desc->attr); // Requires: GetSampleEventInfo() succeeded.
-    return event_desc->attr->sample_type;
 }

--- a/libtracepoint-decode-cpp/src/PerfEventMetadata.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventMetadata.cpp
@@ -697,6 +697,7 @@ PerfEventMetadata::~PerfEventMetadata()
 
 PerfEventMetadata::PerfEventMetadata() noexcept
     : m_systemName()
+    , m_formatFileContents()
     , m_name()
     , m_printFmt()
     , m_fields()
@@ -730,6 +731,7 @@ PerfEventMetadata::Parse(
     Clear();
 
     m_systemName = systemName;
+    m_formatFileContents = formatFileContents;
 
     bool foundId = false;
     auto p = formatFileContents.data();


### PR DESCRIPTION
Added new `PerfDataFileWriter` class that supports generating `perf.data` files.

Some changes in other classes so that they work consistently with the new `PerfDataFileWriter` class. See CHANGELOG for details. In short,

- The event interchange classes have been changed to expose more information and to expose it more efficiently/consistently.
- The data file reader has been updated to work consistently with the updated interchange classes.
- The session manager has been updated to work consistently with the updated interchange classes.

Note that this does not include support for the session manager saving to a perf.data file. That will come in a separate PR.