### PR TITLE
TracepointSession: Support time filter for save file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LinuxTracepoints Change Log
 
-## v1.3.0 (TBD)
+## v1.3.0 (2023-11-27)
 
 - **Breaking changes** to `PerfDataFile`:
   - `dataFile.AttrCount()` method replaced by `EventDescCount()` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,20 @@
 
 ## v1.3.0 (TBD)
 
-- **Breaking changes** to `PerfDataFile` and `PerfSampleEventInfo` classes:
+- **Breaking changes** to `PerfDataFile`:
   - `dataFile.AttrCount()` method replaced by `EventDescCount()` method.
   - `dataFile.Attr(index)` method replaced by `EventDesc(index)` method.
     The returned `PerfEventDesc` object contains an `attr` pointer.
   - `dataFile.EventDescById(id)` method replaced by `FindEventDescById(id)`.
+- **Breaking changes** to `PerfSampleEventInfo`:
   - `eventInfo.session` field renamed to `session_info`.
   - `eventInfo.attr` field replaced by `Attr()` method.
   - `eventInfo.name` field replaced by `Name()` method.
   - `eventInfo.sample_type` field replaced by `SampleType()` method.
   - `eventInfo.raw_meta` field replaced by `Metadata()` method.
+- **Breaking changes** to `TracepointSession`:
+  - `session.EnableTracePoint(...)` method renamed to `EnableTracepoint(...)`.
+  - `session.DisableTracePoint(...)` method renamed to `DisableTracepoint(...)`.
 - `EventFormatter` formats timestamps as date-time if clock information is
   available in the event metadata. If clock information is not present, it
   continues to format timestamps as seconds.
@@ -31,7 +35,7 @@
   - New: try `/sys/kernel/tracing/user_events_data`; if that doesn't exist,
     parse `/proc/mounts` to find the `tracefs` or `debugfs` mount point.
   - Rationale: Probe an absolute path so that containers don't have to
-    create a fake `/proc/mounts` and for efficiency.
+    create a fake `/proc/mounts` and for efficiency in the common case.
 
 ## v1.2.1 (2023-07-24)
 

--- a/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
@@ -122,7 +122,8 @@ namespace tracepoint_control
         TracepointSession session(
             cache,
             TracepointSessionOptions(TracepointSessionMode::RealTime, 65536) // Required
-                .WakeupWatermark(32768));                                    // Optional
+                .WakeupWatermark(32768)                                      // Optional
+                );
     */
     class TracepointSessionOptions
     {
@@ -245,6 +246,91 @@ namespace tracepoint_control
         bool m_wakeupUseWatermark;
         uint32_t m_wakeupValue;
         uint32_t m_sampleType;
+    };
+
+    /*
+    Configuration settings for TracepointSession::SavePerfDataFile.
+
+    Example:
+
+        error = session.SavePerfDataFile(
+            "perf.data",
+            TracepointSavePerfDataFileOptions().OpenMode(S_IRUSR | S_IWUSR));
+    */
+    class TracepointSavePerfDataFileOptions
+    {
+        friend class TracepointSession;
+
+    public:
+
+        /*
+        Initializes a TracepointSavePerfDataFileOptions to use the default settings.
+
+        - OpenMode = -1 (use default file permissions based on process umask).
+        - TimestampFilter = 0..MAX_UINT64 (no timestamp filtering).
+        - TimestampRange = nullptr (do not return timestamp range).
+        */
+        constexpr
+        TracepointSavePerfDataFileOptions() noexcept
+            : m_openMode(-1)
+            , m_timestampFilterMin(0)
+            , m_timestampFilterMax(UINT64_MAX)
+            , m_timestampRangeFirst(nullptr)
+            , m_timestampRangeLast(nullptr)
+        {
+            return;
+        }
+
+        /*
+        Sets the permissions mode to use when creating the perf.data file. The file will
+        be created as: open(perfDataFileName, O_CREAT|O_WRONLY|O_TRUNC|O_CLOEXEC, OpenMode).
+
+        Default value is -1 (use default file permissions based on process umask).
+        This can be one or more of S_IRUSR, S_IWUSR, S_IRGRP, S_IWGRP, etc.
+        */
+        constexpr TracepointSavePerfDataFileOptions&
+        OpenMode(int openMode) noexcept
+        {
+            m_openMode = openMode;
+            return *this;
+        }
+
+        /*
+        Sets the timestamp filter. Only sample events where
+        timeMin <= event.timestamp <= timeMax will be written to the file. (Timestamp on
+        non-sample events will be ignored.)
+
+        Default value is 0..UINT64_MAX (no timestamp filter).
+        */
+        constexpr TracepointSavePerfDataFileOptions&
+        TimestampFilter(uint64_t filterMin, uint64_t filterMax = UINT64_MAX) noexcept
+        {
+            m_timestampFilterMin = filterMin;
+            m_timestampFilterMax = filterMax;
+            return *this;
+        }
+
+        /*
+        Sets the variables that will receive the timestamp range of the events that were
+        written to the file.
+
+        Default value is nullptr (do not return timestamp range).
+        */
+        constexpr TracepointSavePerfDataFileOptions&
+        TimestampRange(_Out_opt_ uint64_t* first, _Out_opt_ uint64_t* last = nullptr) noexcept
+        {
+            m_timestampRangeFirst = first;
+            m_timestampRangeLast = last;
+            return *this;
+        }
+
+    private:
+
+        int m_openMode;
+        uint64_t m_timestampFilterMin;
+        uint64_t m_timestampFilterMax;
+        uint64_t* m_timestampRangeFirst;
+        uint64_t* m_timestampRangeLast;
     };
 
     /*
@@ -644,7 +730,7 @@ namespace tracepoint_control
         - ENOMEM: memory allocation failed.
         */
         _Success_(return == 0) int
-        DisableTracePoint(unsigned id) noexcept;
+        DisableTracepoint(unsigned id) noexcept;
 
         /*
         Disables collection of the specified tracepoint.
@@ -666,7 +752,7 @@ namespace tracepoint_control
         - ENOMEM: memory allocation failed.
         */
         _Success_(return == 0) int
-        DisableTracePoint(TracepointName name) noexcept;
+        DisableTracepoint(TracepointName name) noexcept;
 
         /*
         Enables collection of the specified tracepoint.
@@ -687,7 +773,7 @@ namespace tracepoint_control
         - ENOMEM: memory allocation failed.
         */
         _Success_(return == 0) int
-        EnableTracePoint(unsigned id) noexcept;
+        EnableTracepoint(unsigned id) noexcept;
 
         /*
         Enables collection of the specified tracepoint.
@@ -705,7 +791,7 @@ namespace tracepoint_control
         - ENOMEM: memory allocation failed.
         */
         _Success_(return == 0) int
-        EnableTracePoint(TracepointName name) noexcept;
+        EnableTracepoint(TracepointName name) noexcept;
 
         /*
         Returns a range for enumerating the tracepoints in the session (includes
@@ -795,7 +881,7 @@ namespace tracepoint_control
 
         File is created as:
 
-            open(perfDataFileName, O_CREAT|O_WRONLY|O_TRUNC|O_CLOEXEC, mode);
+            open(perfDataFileName, O_CREAT|O_WRONLY|O_TRUNC|O_CLOEXEC, options.OpenMode());
 
         Returns: int error code (errno), or 0 for success.
 
@@ -829,7 +915,7 @@ namespace tracepoint_control
         _Success_(return == 0) int
         SavePerfDataFile(
             _In_z_ char const* perfDataFileName,
-            int mode = -1) noexcept;
+            TracepointSavePerfDataFileOptions const& options = TracepointSavePerfDataFileOptions()) noexcept;
 
         /*
         For each PERF_RECORD_SAMPLE record in the session's buffers, in timestamp
@@ -1054,10 +1140,10 @@ namespace tracepoint_control
     private:
 
         _Success_(return == 0) int
-        DisableTracePointImpl(tracepoint_decode::PerfEventMetadata const& metadata) noexcept;
+        DisableTracepointImpl(tracepoint_decode::PerfEventMetadata const& metadata) noexcept;
 
         _Success_(return == 0) int
-        EnableTracePointImpl(tracepoint_decode::PerfEventMetadata const& metadata) noexcept;
+        EnableTracepointImpl(tracepoint_decode::PerfEventMetadata const& metadata) noexcept;
 
         _Success_(return == 0) static int
         IoctlForEachFile(
@@ -1084,8 +1170,21 @@ namespace tracepoint_control
             uint32_t bufferIndex,
             RecordFn&& recordFn) noexcept(noexcept(recordFn(nullptr, 0, 0)));
 
+        _Success_(return == 0) int
+        SetTracepointEnableState(
+            TracepointInfoImpl& tpi,
+            bool enabled) noexcept;
+
+        _Success_(return == 0) int
+        AddTracepoint(
+            tracepoint_decode::PerfEventMetadata const& metadata,
+            TracepointEnableState enableState) noexcept(false);
+
     private:
 
+        // Constant
+
+        tracepoint_decode::PerfEventSessionInfo const m_sessionInfo;
         TracepointCache& m_cache;
         TracepointSessionMode const m_mode;
         bool const m_wakeupUseWatermark;
@@ -1094,18 +1193,26 @@ namespace tracepoint_control
         uint32_t const m_bufferCount;
         uint32_t const m_pageSize;
         uint32_t const m_bufferSize;
+
+        // State
+
         std::unique_ptr<BufferInfo[]> const m_buffers; // size is m_bufferCount
         std::unordered_map<unsigned, TracepointInfoImpl> m_tracepointInfoByCommonType;
         std::unordered_map<uint64_t, TracepointInfoImpl const*> m_tracepointInfoBySampleId;
-        std::vector<uint8_t> m_eventDataBuffer; // Double-buffer for events that wrap.
-        std::vector<TracepointBookmark> m_enumeratorBookmarks;
-        std::unique_ptr<pollfd[]> m_pollfd;
         unique_fd const* m_bufferLeaderFiles; // == m_tracepointInfoByCommonType[N].BufferFiles.get() for some N, size is m_bufferCount
+
+        // Statistics
+
         uint64_t m_sampleEventCount;
         uint64_t m_lostEventCount;
         uint64_t m_corruptEventCount;
         uint64_t m_corruptBufferCount;
-        tracepoint_decode::PerfEventSessionInfo m_sessionInfo;
+
+        // Transient
+
+        std::vector<uint8_t> m_eventDataBuffer; // Double-buffer for events that wrap.
+        std::vector<TracepointBookmark> m_enumeratorBookmarks;
+        std::unique_ptr<pollfd[]> m_pollfd;
         tracepoint_decode::PerfSampleEventInfo m_enumEventInfo;
     };
 

--- a/libtracepoint-control-cpp/samples/control-session.cpp
+++ b/libtracepoint-control-cpp/samples/control-session.cpp
@@ -67,8 +67,8 @@ main(int argc, char* argv[])
     unsigned enabled = 0;
     for (int argi = 2; argi < argc; argi += 1)
     {
-        error = session.EnableTracePoint(TracepointName(argv[argi]));
-        fprintf(stderr, "EnableTracePoint(%s) = %u\n", argv[argi], error);
+        error = session.EnableTracepoint(TracepointName(argv[argi]));
+        fprintf(stderr, "EnableTracepoint(%s) = %u\n", argv[argi], error);
         enabled += error == 0;
     }
 

--- a/libtracepoint-control-cpp/samples/save-session.cpp
+++ b/libtracepoint-control-cpp/samples/save-session.cpp
@@ -23,6 +23,7 @@ int
 main(int argc, char* argv[])
 {
     int error = 0;
+    uint64_t lastWritten = UINT64_MAX; // So that lastWritten + 1 == 0
 
     if (argc < 3 ||
         (0 != strcmp(argv[1], "0") && 0 != strcmp(argv[1], "1")))
@@ -95,7 +96,11 @@ main(int argc, char* argv[])
         char outFileName[256];
         snprintf(outFileName, sizeof(outFileName), "%s.%u", argv[2], i);
 
-        error = session.SavePerfDataFile(outFileName);
+        error = session.SavePerfDataFile(
+            outFileName,
+            TracepointSavePerfDataFileOptions()
+            .TimestampFilter(lastWritten + 1)
+            .TimestampWrittenRange(nullptr, &lastWritten));
         printf("SavePerfDataFile(%s) = %u\n", outFileName, error);
     }
 

--- a/libtracepoint-control-cpp/samples/save-session.cpp
+++ b/libtracepoint-control-cpp/samples/save-session.cpp
@@ -68,8 +68,8 @@ main(int argc, char* argv[])
     unsigned enabled = 0;
     for (int argi = 3; argi < argc; argi += 1)
     {
-        error = session.EnableTracePoint(TracepointName(argv[argi]));
-        fprintf(stderr, "EnableTracePoint(%s) = %u\n", argv[argi], error);
+        error = session.EnableTracepoint(TracepointName(argv[argi]));
+        fprintf(stderr, "EnableTracepoint(%s) = %u\n", argv[argi], error);
         enabled += error == 0;
     }
 

--- a/libtracepoint-control-cpp/src/TracepointSession.cpp
+++ b/libtracepoint-control-cpp/src/TracepointSession.cpp
@@ -74,107 +74,144 @@ RoundUpBufferSize(uint32_t pageSize, size_t bufferSize) noexcept
     return BufferSizeMax;
 }
 
-/*
-Manages a scatter-gather list of chunks of memory that need to be written to
-the perf.data file. This allows us to reduce the number of kernel calls.
-Instead of calling write() once per event (or twice if the event wraps), we
-call writev once for every 16 noncontinguous blocks of memory to be written.
-*/
-class IovecList
+static tracepoint_decode::PerfEventSessionInfo
+MakeSessionInfo(uint32_t clockid) noexcept
 {
-    static constexpr unsigned Max = 16;
-    unsigned m_used = 0;
-    iovec m_vecs[Max];
+    static const auto Billion = 1000000000u;
 
-public:
+    tracepoint_decode::PerfEventSessionInfo sessionInfo;
+    sessionInfo.SetClockid(clockid);
 
-    unsigned
-    RoomLeft() const noexcept
+    timespec monotonic;
+    timespec realtime;
+    if (0 == clock_gettime(clockid, &monotonic) &&
+        0 == clock_gettime(CLOCK_REALTIME, &realtime))
     {
-        return Max - m_used;
-    }
-
-    void
-    Add(uint8_t const* p, size_t c) noexcept
-    {
-        assert(m_used < Max); // Caller is responsible for checking RoomLeft().
-        auto const lastVec = m_used - 1;
-        if (0 != m_used &&
-            p == static_cast<uint8_t*>(m_vecs[lastVec].iov_base) + m_vecs[lastVec].iov_len)
+        uint64_t monotonicNS, realtimeNS;
+        if (monotonic.tv_sec < realtime.tv_sec ||
+            (monotonic.tv_sec == realtime.tv_sec && monotonic.tv_nsec < realtime.tv_nsec))
         {
-            // This block immediately follows the last block. Merge the blocks.
-            m_vecs[lastVec].iov_len += c;
+            monotonicNS = 0;
+            realtimeNS = static_cast<uint64_t>(realtime.tv_sec - monotonic.tv_sec) * Billion
+                + realtime.tv_nsec - monotonic.tv_nsec;
         }
         else
         {
-            m_vecs[m_used].iov_base = const_cast<uint8_t*>(p);
-            m_vecs[m_used].iov_len = c;
-            m_used += 1;
+            realtimeNS = 0;
+            monotonicNS = static_cast<uint64_t>(monotonic.tv_sec - realtime.tv_sec) * Billion
+                + monotonic.tv_nsec - realtime.tv_nsec;
         }
+
+        sessionInfo.SetClockData(clockid, realtimeNS, monotonicNS);
     }
 
-    _Success_(return == 0) int
-    Flush(PerfDataFileWriter& output) noexcept
+    return sessionInfo;
+}
+
+namespace
+{
+    /*
+    Manages a scatter-gather list of chunks of memory that need to be written to
+    the perf.data file. This allows us to reduce the number of kernel calls.
+    Instead of calling write() once per event (or twice if the event wraps), we
+    call writev once for every 16 noncontinguous blocks of memory to be written.
+    */
+    class IovecList
     {
-        assert(m_used <= Max);
+        static constexpr unsigned Max = 16;
+        unsigned m_used = 0;
+        iovec m_vecs[Max];
 
-        int error;
-        if (m_used == 0)
+    public:
+
+        unsigned
+        RoomLeft() const noexcept
         {
-            error = 0;
-        }
-        else
-        {
-            size_t cbToWrite = 0;
-            for (unsigned i = 0; i != m_used; i += 1)
-            {
-                cbToWrite += m_vecs[i].iov_len;
-                if (cbToWrite < m_vecs[i].iov_len)
-                {
-                    error = ERANGE;
-                    goto Done;
-                }
-            }
-
-            for (auto skip = 0u;;)
-            {
-                auto const cbWritten = output.WriteEventDataIovecs(m_vecs + skip, m_used - skip);
-                if (cbWritten < 0)
-                {
-                    error = errno;
-                    break;
-                }
-                else if (static_cast<size_t>(cbWritten) == cbToWrite)
-                {
-                    error = 0;
-                    break;
-                }
-
-                // Partial write. Skip what was written and try again.
-
-                auto cbToSkip = static_cast<size_t>(cbWritten);
-                assert(cbToWrite > cbToSkip);
-                cbToWrite -= cbToSkip;
-
-                while (cbToSkip >= m_vecs[skip].iov_len)
-                {
-                    cbToSkip -= m_vecs[skip].iov_len;
-                    skip += 1;
-                }
-
-                assert(skip < m_used);
-                m_vecs[skip].iov_base = static_cast<uint8_t*>(m_vecs[skip].iov_base) + cbToSkip;
-                m_vecs[skip].iov_len = m_vecs[skip].iov_len - cbToSkip;
-            }
-
-            m_used = 0;
+            return Max - m_used;
         }
 
-    Done:
+        void
+        Add(uint8_t const* p, size_t c) noexcept
+        {
+            assert(m_used < Max); // Caller is responsible for checking RoomLeft().
+            auto const lastVec = m_used - 1;
+            if (0 != m_used &&
+                p == static_cast<uint8_t*>(m_vecs[lastVec].iov_base) + m_vecs[lastVec].iov_len)
+            {
+                // This block immediately follows the last block. Merge the blocks.
+                m_vecs[lastVec].iov_len += c;
+            }
+            else
+            {
+                m_vecs[m_used].iov_base = const_cast<uint8_t*>(p);
+                m_vecs[m_used].iov_len = c;
+                m_used += 1;
+            }
+        }
 
-        return error;
-    }
-};
+        _Success_(return == 0) int
+        Flush(PerfDataFileWriter& output) noexcept
+        {
+            assert(m_used <= Max);
+
+            int error;
+            if (m_used == 0)
+            {
+                error = 0;
+            }
+            else
+            {
+                size_t cbToWrite = 0;
+                for (unsigned i = 0; i != m_used; i += 1)
+                {
+                    cbToWrite += m_vecs[i].iov_len;
+                    if (cbToWrite < m_vecs[i].iov_len)
+                    {
+                        error = ERANGE;
+                        goto Done;
+                    }
+                }
+
+                for (auto skip = 0u;;)
+                {
+                    auto const cbWritten = output.WriteEventDataIovecs(m_vecs + skip, m_used - skip);
+                    if (cbWritten < 0)
+                    {
+                        error = errno;
+                        break;
+                    }
+                    else if (static_cast<size_t>(cbWritten) == cbToWrite)
+                    {
+                        error = 0;
+                        break;
+                    }
+
+                    // Partial write. Skip what was written and try again.
+
+                    auto cbToSkip = static_cast<size_t>(cbWritten);
+                    assert(cbToWrite > cbToSkip);
+                    cbToWrite -= cbToSkip;
+
+                    while (cbToSkip >= m_vecs[skip].iov_len)
+                    {
+                        cbToSkip -= m_vecs[skip].iov_len;
+                        skip += 1;
+                    }
+
+                    assert(skip < m_used);
+                    m_vecs[skip].iov_base = static_cast<uint8_t*>(m_vecs[skip].iov_base) + cbToSkip;
+                    m_vecs[skip].iov_len = m_vecs[skip].iov_len - cbToSkip;
+                }
+
+                m_used = 0;
+            }
+
+        Done:
+
+            return error;
+        }
+    };
+}
 
 // TracepointInfo
 
@@ -580,7 +617,8 @@ TracepointSession::TracepointSession(
 TracepointSession::TracepointSession(
     TracepointCache& cache,
     TracepointSessionOptions const& options) noexcept(false)
-    : m_cache(cache)
+    : m_sessionInfo(MakeSessionInfo(CLOCK_MONOTONIC_RAW))
+    , m_cache(cache)
     , m_mode(options.m_mode)
     , m_wakeupUseWatermark(options.m_wakeupUseWatermark)
     , m_wakeupValue(options.m_wakeupValue)
@@ -591,46 +629,17 @@ TracepointSession::TracepointSession(
     , m_buffers(std::make_unique<BufferInfo[]>(m_bufferCount)) // may throw bad_alloc.
     , m_tracepointInfoByCommonType() // may throw bad_alloc (but probably doesn't).
     , m_tracepointInfoBySampleId() // may throw bad_alloc (but probably doesn't).
-    , m_eventDataBuffer()
-    , m_enumeratorBookmarks()
-    , m_pollfd(nullptr)
     , m_bufferLeaderFiles(nullptr)
     , m_sampleEventCount(0)
     , m_lostEventCount(0)
     , m_corruptEventCount(0)
     , m_corruptBufferCount(0)
-    , m_sessionInfo()
+    , m_eventDataBuffer()
+    , m_enumeratorBookmarks()
+    , m_pollfd(nullptr)
     , m_enumEventInfo()
 {
-    static const auto Billion = 1000000000u;
-
     assert(options.m_mode <= TracepointSessionMode::RealTime);
-    m_sessionInfo.SetClockid(CLOCK_MONOTONIC_RAW);
-
-    timespec monotonic;
-    timespec realtime;
-    if (0 == clock_gettime(CLOCK_MONOTONIC_RAW, &monotonic) &&
-        0 == clock_gettime(CLOCK_REALTIME, &realtime))
-    {
-        uint64_t monotonicNS, realtimeNS;
-        if (monotonic.tv_sec < realtime.tv_sec ||
-            (monotonic.tv_sec == realtime.tv_sec && monotonic.tv_nsec < realtime.tv_nsec))
-        {
-            monotonicNS = 0;
-            realtimeNS = static_cast<uint64_t>(realtime.tv_sec - monotonic.tv_sec) * Billion
-                + realtime.tv_nsec - monotonic.tv_nsec;
-        }
-        else
-        {
-            realtimeNS = 0;
-            monotonicNS = static_cast<uint64_t>(monotonic.tv_sec - realtime.tv_sec) * Billion
-                + monotonic.tv_nsec - realtime.tv_nsec;
-        }
-
-        m_sessionInfo.SetClockData(CLOCK_MONOTONIC_RAW, realtimeNS, monotonicNS);
-    }
-
-    return;
 }
 
 TracepointCache&
@@ -690,28 +699,34 @@ TracepointSession::CorruptBufferCount() const noexcept
 void
 TracepointSession::Clear() noexcept
 {
-    m_tracepointInfoByCommonType.clear();
-    m_tracepointInfoBySampleId.clear();
-    m_bufferLeaderFiles = nullptr;
     for (uint32_t bufferIndex = 0; bufferIndex != m_bufferCount; bufferIndex += 1)
     {
         m_buffers[bufferIndex].Mmap.reset();
     }
+
+    m_tracepointInfoByCommonType.clear();
+    m_tracepointInfoBySampleId.clear();
+    m_bufferLeaderFiles = nullptr;
+
+    m_sampleEventCount = 0;
+    m_lostEventCount = 0;
+    m_corruptEventCount = 0;
+    m_corruptBufferCount = 0;
 }
 
 _Success_(return == 0) int
-TracepointSession::DisableTracePoint(unsigned id) noexcept
+TracepointSession::DisableTracepoint(unsigned id) noexcept
 {
     auto const metadata = m_cache.FindById(id);
     auto const error = metadata == nullptr
         ? ENOENT
-        : DisableTracePointImpl(*metadata);
+        : DisableTracepointImpl(*metadata);
 
     return error;
 }
 
 _Success_(return == 0) int
-TracepointSession::DisableTracePoint(TracepointName name) noexcept
+TracepointSession::DisableTracepoint(TracepointName name) noexcept
 {
     int error;
 
@@ -719,25 +734,25 @@ TracepointSession::DisableTracePoint(TracepointName name) noexcept
     error = m_cache.FindOrAddFromSystem(name, &metadata);
     if (error == 0)
     {
-        error = DisableTracePointImpl(*metadata);
+        error = DisableTracepointImpl(*metadata);
     }
 
     return error;
 }
 
 _Success_(return == 0) int
-TracepointSession::EnableTracePoint(unsigned id) noexcept
+TracepointSession::EnableTracepoint(unsigned id) noexcept
 {
     auto const metadata = m_cache.FindById(id);
     auto const error = metadata == nullptr
         ? ENOENT
-        : EnableTracePointImpl(*metadata);
+        : EnableTracepointImpl(*metadata);
 
     return error;
 }
 
 _Success_(return == 0) int
-TracepointSession::EnableTracePoint(TracepointName name) noexcept
+TracepointSession::EnableTracepoint(TracepointName name) noexcept
 {
     int error;
 
@@ -745,7 +760,7 @@ TracepointSession::EnableTracePoint(TracepointName name) noexcept
     error = m_cache.FindOrAddFromSystem(name, &metadata);
     if (error == 0)
     {
-        error = EnableTracePointImpl(*metadata);
+        error = EnableTracepointImpl(*metadata);
     }
 
     return error;
@@ -861,7 +876,7 @@ TracepointSession::GetBufferFiles(
 _Success_(return == 0) int
 TracepointSession::SavePerfDataFile(
     _In_z_ char const* perfDataFileName,
-    int mode) noexcept
+    TracepointSavePerfDataFileOptions const& options) noexcept
 {
     int error = 0;
     PerfDataFileWriter output;
@@ -871,7 +886,17 @@ TracepointSession::SavePerfDataFile(
         uint64_t last;
     } times = { ~uint64_t(0), 0 };
 
-    error = output.Create(perfDataFileName, mode);
+    if (options.m_timestampRangeFirst)
+    {
+        *options.m_timestampRangeFirst = 0;
+    }
+
+    if (options.m_timestampRangeLast)
+    {
+        *options.m_timestampRangeLast = 0;
+    }
+
+    error = output.Create(perfDataFileName, options.m_openMode);
     if (error != 0)
     {
         goto Done;
@@ -881,7 +906,7 @@ TracepointSession::SavePerfDataFile(
 
     if (m_bufferLeaderFiles != nullptr)
     {
-        auto recordFn = [this, &vecList, &times](
+        auto recordFn = [this, &vecList, &times, &options](
             uint8_t const* bufferData,
             uint16_t recordSize,
             uint32_t recordBufferPos) noexcept
@@ -913,6 +938,15 @@ TracepointSession::SavePerfDataFile(
                 // If this succeeds it will set m_enumEventInfo.
                 if (ParseSample(bufferData, recordSize, recordBufferPos))
                 {
+                    if (options.m_timestampFilterMin > m_enumEventInfo.time ||
+                        options.m_timestampFilterMax < m_enumEventInfo.time)
+                    {
+                        // TODO: Optimization - in some cases, this means we're going
+                        // to skip the rest of the buffer, so perhaps detect those
+                        // cases and stop the enumeration?
+                        return false; // Skip this event.
+                    }
+
                     if (m_enumEventInfo.time < times.first)
                     {
                         times.first = m_enumEventInfo.time;
@@ -1002,6 +1036,16 @@ TracepointSession::SavePerfDataFile(
         {
             goto Done;
         }
+
+        if (options.m_timestampRangeFirst)
+        {
+            *options.m_timestampRangeFirst = times.first;
+        }
+
+        if (options.m_timestampRangeLast)
+        {
+            *options.m_timestampRangeLast = times.last;
+        }
     }
 
     // CLOCKID, CLOCK_DATA
@@ -1021,220 +1065,37 @@ Done:
 }
 
 _Success_(return == 0) int
-TracepointSession::DisableTracePointImpl(PerfEventMetadata const& metadata) noexcept
+TracepointSession::DisableTracepointImpl(PerfEventMetadata const& metadata) noexcept
 {
     int error;
 
-    auto const it = m_tracepointInfoByCommonType.find(metadata.Id());
-    if (it == m_tracepointInfoByCommonType.end())
+    auto const existingIt = m_tracepointInfoByCommonType.find(metadata.Id());
+    if (existingIt == m_tracepointInfoByCommonType.end())
     {
         error = ENOENT;
     }
-    else if (it->second.m_enableState == TracepointEnableState::Disabled)
-    {
-        error = 0;
-    }
     else
     {
-        error = IoctlForEachFile(it->second.m_bufferFiles.get(), m_bufferCount, PERF_EVENT_IOC_DISABLE, nullptr);
-        it->second.m_enableState = error
-            ? TracepointEnableState::Unknown
-            : TracepointEnableState::Disabled;
+        error = SetTracepointEnableState(existingIt->second, false);
     }
 
     return error;
 }
 
 _Success_(return == 0) int
-TracepointSession::EnableTracePointImpl(PerfEventMetadata const& metadata) noexcept
+TracepointSession::EnableTracepointImpl(PerfEventMetadata const& metadata) noexcept
 {
     int error;
-    uint32_t cIdsAdded = 0;
-    uint64_t* pIds = nullptr;
 
-    auto existingIt = m_tracepointInfoByCommonType.find(metadata.Id());
-    if (existingIt != m_tracepointInfoByCommonType.end())
+    auto const existingIt = m_tracepointInfoByCommonType.find(metadata.Id());
+    if (existingIt == m_tracepointInfoByCommonType.end())
     {
-        // Event already in list. Make sure it's enabled.
-        if (existingIt->second.m_enableState == TracepointEnableState::Enabled)
-        {
-            error = 0;
-        }
-        else
-        {
-            auto const& tpi = existingIt->second;
-            error = IoctlForEachFile(
-                tpi.m_bufferFiles.get(),
-                tpi.m_bufferFilesCount,
-                PERF_EVENT_IOC_ENABLE,
-                nullptr);
-            existingIt->second.m_enableState = error
-                ? TracepointEnableState::Unknown
-                : TracepointEnableState::Enabled;
-        }
-
-        // Note: skip cleanup, even for error case.
-        goto Done;
+        error = AddTracepoint(metadata, TracepointEnableState::Enabled);
     }
-
-    try
+    else
     {
-        auto const systemName = metadata.SystemName();
-        auto const eventName = metadata.Name();
-        auto const cbEventDescStorage =
-            sizeof(perf_event_attr) +
-            m_bufferCount * sizeof(uint64_t) +
-            systemName.size() + 1 + eventName.size() + 1;
-        auto eventDescStorage = std::make_unique<char unsigned[]>(cbEventDescStorage);
-
-        auto const pAttr = reinterpret_cast<perf_event_attr*>(eventDescStorage.get());
-        pAttr->type = PERF_TYPE_TRACEPOINT;
-        pAttr->size = sizeof(perf_event_attr);
-        pAttr->config = metadata.Id();
-        pAttr->sample_period = 1;
-        pAttr->sample_type = m_sampleType;
-        pAttr->read_format = PERF_FORMAT_ID; // Must match definition of struct ReadFormat.
-        pAttr->watermark = m_wakeupUseWatermark;
-        pAttr->use_clockid = 1;
-        pAttr->write_backward = !IsRealtime();
-        pAttr->wakeup_events = m_wakeupValue;
-        pAttr->clockid = CLOCK_MONOTONIC_RAW;
-
-        // pIds will be initialized after file handle creation.
-        pIds = reinterpret_cast<uint64_t*>(pAttr + 1);
-
-        auto const pName = reinterpret_cast<char*>(pIds + m_bufferCount);
-        {
-            size_t i = 0;
-            memcpy(&pName[i], systemName.data(), systemName.size());
-            i += systemName.size();
-            pName[i] = ':';
-            i += 1;
-            memcpy(&pName[i], eventName.data(), eventName.size());
-            i += eventName.size();
-            pName[i] = '\0';
-        }
-
-        PerfEventDesc const eventDesc = {
-            pAttr,
-            pName,
-            &metadata,
-            pIds,
-            m_bufferCount
-        };
-
-        auto er = m_tracepointInfoByCommonType.try_emplace(metadata.Id(),
-            eventDesc,
-            std::move(eventDescStorage),
-            std::make_unique<unique_fd[]>(m_bufferCount),
-            m_bufferCount);
-        assert(er.second);
-        auto& tpi = er.first->second;
-
-        // Starting from here, if there is an error then we must erase(metadata.Id).
-
-        for (uint32_t bufferIndex = 0; bufferIndex != m_bufferCount; bufferIndex += 1)
-        {
-            errno = 0;
-            tpi.m_bufferFiles[bufferIndex].reset(perf_event_open(pAttr, -1, bufferIndex, -1, PERF_FLAG_FD_CLOEXEC));
-            if (!tpi.m_bufferFiles[bufferIndex])
-            {
-                error = errno;
-                if (error == 0)
-                {
-                    error = ENODEV;
-                }
-
-                goto Error;
-            }
-        }
-
-        if (m_bufferLeaderFiles)
-        {
-            // Leader already exists. Add this event to the leader's mmaps.
-            error = IoctlForEachFile(tpi.m_bufferFiles.get(), m_bufferCount, PERF_EVENT_IOC_SET_OUTPUT, m_bufferLeaderFiles);
-            if (error)
-            {
-                goto Error;
-            }
-        }
-        else
-        {
-            auto const mmapSize = m_pageSize + m_bufferSize;
-            auto const prot = IsRealtime()
-                ? PROT_READ | PROT_WRITE
-                : PROT_READ;
-
-            // This is the first event. Make it the "leader".
-            for (uint32_t bufferIndex = 0; bufferIndex != m_bufferCount; bufferIndex += 1)
-            {
-                errno = 0;
-                auto cpuMap = mmap(nullptr, mmapSize, prot, MAP_SHARED, tpi.m_bufferFiles[bufferIndex].get(), 0);
-                if (MAP_FAILED == cpuMap)
-                {
-                    error = errno;
-
-                    // Clean up any mmaps that we opened.
-                    for (uint32_t bufferIndex2 = 0; bufferIndex2 != bufferIndex; bufferIndex2 += 1)
-                    {
-                        m_buffers[bufferIndex2].Mmap.reset();
-                    }
-
-                    if (error == 0)
-                    {
-                        error = ENODEV;
-                    }
-
-                    goto Error;
-                }
-
-                m_buffers[bufferIndex].Mmap.reset(cpuMap, mmapSize);
-            }
-        }
-
-        // Find the sample_ids for the new tracepoints.
-        for (; cIdsAdded != m_bufferCount; cIdsAdded += 1)
-        {
-            ReadFormat data;
-            error = tpi.Read(cIdsAdded, &data);
-            if (error != 0)
-            {
-                goto Error;
-            }
-
-            pIds[cIdsAdded] = data.id;
-
-            auto const added = m_tracepointInfoBySampleId.emplace(data.id, &tpi).second;
-            assert(added);
-            (void)added;
-        }
-
-        if (!m_bufferLeaderFiles)
-        {
-            m_bufferLeaderFiles = tpi.m_bufferFiles.get(); // Commit this event as the leader.
-        }
-
-        tpi.m_enableState = TracepointEnableState::Enabled;
-        error = 0;
-        goto Done;
+        error = SetTracepointEnableState(existingIt->second, true);
     }
-    catch (...)
-    {
-        error = ENOMEM;
-        goto Error;
-    }
-
-Error:
-
-    for (uint32_t i = 0; i != cIdsAdded; i += 1)
-    {
-        m_tracepointInfoBySampleId.erase(pIds[i]);
-    }
-
-    // May or may not have been added yet. If not, erase does nothing.
-    m_tracepointInfoByCommonType.erase(metadata.Id());
-
-Done:
 
     return error;
 }
@@ -1736,4 +1597,218 @@ TracepointSession::EnumeratorMoveNext(
     }
 
     return false;
+}
+
+_Success_(return == 0) int
+TracepointSession::SetTracepointEnableState(
+    TracepointInfoImpl & tpi,
+    bool enabled) noexcept
+{
+    int error;
+
+    static auto const UnknownState = TracepointEnableState::Unknown;
+    auto const desiredState = enabled
+        ? TracepointEnableState::Enabled
+        : TracepointEnableState::Disabled;
+
+    if (desiredState == tpi.m_enableState)
+    {
+        error = 0;
+        goto Done;
+    }
+
+    tpi.m_enableState = UnknownState;
+
+    error = IoctlForEachFile(
+        tpi.m_bufferFiles.get(),
+        tpi.m_bufferFilesCount,
+        enabled ? PERF_EVENT_IOC_ENABLE : PERF_EVENT_IOC_DISABLE,
+        nullptr);
+    if (error == 0)
+    {
+        tpi.m_enableState = desiredState;
+    }
+
+Done:
+
+    return error;
+}
+
+_Success_(return == 0) int
+TracepointSession::AddTracepoint(
+    PerfEventMetadata const& metadata,
+    TracepointEnableState enableState) noexcept(false)
+{
+    int error;
+    uint32_t cIdsAdded = 0;
+    uint64_t* pIds = nullptr;
+
+    try
+    {
+        auto const systemName = metadata.SystemName();
+        auto const eventName = metadata.Name();
+        if (systemName.size() > 65535 ||
+            eventName.size() > 65535)
+        {
+            error = E2BIG;
+            goto Error;
+        }
+
+        auto const cbEventDescStorage =
+            sizeof(perf_event_attr) +
+            m_bufferCount * sizeof(uint64_t) +
+            systemName.size() + 1 + eventName.size() + 1;
+        auto eventDescStorage = std::make_unique<char unsigned[]>(cbEventDescStorage);
+
+        auto const pAttr = reinterpret_cast<perf_event_attr*>(eventDescStorage.get());
+        pAttr->type = PERF_TYPE_TRACEPOINT;
+        pAttr->size = sizeof(perf_event_attr);
+        pAttr->config = metadata.Id();
+        pAttr->sample_period = 1;
+        pAttr->sample_type = m_sampleType;
+        pAttr->read_format = PERF_FORMAT_ID; // Must match definition of struct ReadFormat.
+        pAttr->watermark = m_wakeupUseWatermark;
+        pAttr->use_clockid = 1;
+        pAttr->write_backward = !IsRealtime();
+        pAttr->wakeup_events = m_wakeupValue;
+        pAttr->clockid = m_sessionInfo.ClockId();
+
+        // pIds will be initialized after file handle creation.
+        // cIdsAdded tracks initialization.
+        pIds = reinterpret_cast<uint64_t*>(pAttr + 1);
+
+        auto const pName = reinterpret_cast<char*>(pIds + m_bufferCount);
+        {
+            size_t i = 0;
+            memcpy(&pName[i], systemName.data(), systemName.size());
+            i += systemName.size();
+            pName[i] = ':';
+            i += 1;
+            memcpy(&pName[i], eventName.data(), eventName.size());
+            i += eventName.size();
+            pName[i] = '\0';
+        }
+
+        PerfEventDesc const eventDesc = {
+            pAttr,
+            pName,
+            &metadata,
+            pIds,
+            m_bufferCount
+        };
+
+        auto er = m_tracepointInfoByCommonType.try_emplace(metadata.Id(),
+            eventDesc,
+            std::move(eventDescStorage),
+            std::make_unique<unique_fd[]>(m_bufferCount),
+            m_bufferCount);
+        assert(er.second);
+        auto& tpi = er.first->second;
+        tpi.m_enableState = enableState;
+
+        // Starting from here, if there is an error then we must erase(metadata.Id).
+
+        for (uint32_t bufferIndex = 0; bufferIndex != m_bufferCount; bufferIndex += 1)
+        {
+            errno = 0;
+            tpi.m_bufferFiles[bufferIndex].reset(perf_event_open(pAttr, -1, bufferIndex, -1, PERF_FLAG_FD_CLOEXEC));
+            if (!tpi.m_bufferFiles[bufferIndex])
+            {
+                error = errno;
+                if (error == 0)
+                {
+                    error = ENODEV;
+                }
+
+                goto Error;
+            }
+        }
+
+        if (m_bufferLeaderFiles)
+        {
+            // Leader already exists. Add this event to the leader's mmaps.
+            error = IoctlForEachFile(tpi.m_bufferFiles.get(), m_bufferCount, PERF_EVENT_IOC_SET_OUTPUT, m_bufferLeaderFiles);
+            if (error)
+            {
+                goto Error;
+            }
+        }
+        else
+        {
+            // This is the first event. Make it the "leader" (the owner of the session buffers).
+            auto const mmapSize = m_pageSize + m_bufferSize;
+            auto const prot = IsRealtime()
+                ? PROT_READ | PROT_WRITE
+                : PROT_READ;
+            for (uint32_t bufferIndex = 0; bufferIndex != m_bufferCount; bufferIndex += 1)
+            {
+                errno = 0;
+                auto cpuMap = mmap(nullptr, mmapSize, prot, MAP_SHARED, tpi.m_bufferFiles[bufferIndex].get(), 0);
+                if (MAP_FAILED == cpuMap)
+                {
+                    error = errno;
+
+                    // Clean up any mmaps that we opened.
+                    for (uint32_t bufferIndex2 = 0; bufferIndex2 != bufferIndex; bufferIndex2 += 1)
+                    {
+                        m_buffers[bufferIndex2].Mmap.reset();
+                    }
+
+                    if (error == 0)
+                    {
+                        error = ENODEV;
+                    }
+
+                    goto Error;
+                }
+
+                m_buffers[bufferIndex].Mmap.reset(cpuMap, mmapSize);
+            }
+        }
+
+        // Find the sample_ids for the new tracepoints.
+        for (; cIdsAdded != m_bufferCount; cIdsAdded += 1)
+        {
+            ReadFormat data;
+            error = tpi.Read(cIdsAdded, &data);
+            if (error != 0)
+            {
+                goto Error;
+            }
+
+            pIds[cIdsAdded] = data.id;
+
+            auto const added = m_tracepointInfoBySampleId.emplace(data.id, &tpi).second;
+            assert(added);
+            (void)added;
+        }
+
+        // Success. Commit it. (No exceptions beyond this point.)
+
+        if (!m_bufferLeaderFiles)
+        {
+            m_bufferLeaderFiles = tpi.m_bufferFiles.get(); // Commit this event as the leader.
+        }
+
+        goto Done;
+    }
+    catch (...)
+    {
+        error = ENOMEM;
+        goto Error;
+    }
+
+Error:
+
+    for (uint32_t i = 0; i != cIdsAdded; i += 1)
+    {
+        m_tracepointInfoBySampleId.erase(pIds[i]);
+    }
+
+    // May or may not have been added yet. If not, erase does nothing.
+    m_tracepointInfoByCommonType.erase(metadata.Id());
+
+Done:
+
+    return error;
 }

--- a/libtracepoint-control-cpp/src/TracepointSession.cpp
+++ b/libtracepoint-control-cpp/src/TracepointSession.cpp
@@ -886,14 +886,14 @@ TracepointSession::SavePerfDataFile(
         uint64_t last;
     } times = { ~uint64_t(0), 0 };
 
-    if (options.m_timestampRangeFirst)
+    if (options.m_timestampWrittenRangeFirst)
     {
-        *options.m_timestampRangeFirst = 0;
+        *options.m_timestampWrittenRangeFirst = 0;
     }
 
-    if (options.m_timestampRangeLast)
+    if (options.m_timestampWrittenRangeLast)
     {
-        *options.m_timestampRangeLast = 0;
+        *options.m_timestampWrittenRangeLast = 0;
     }
 
     error = output.Create(perfDataFileName, options.m_openMode);
@@ -911,21 +911,6 @@ TracepointSession::SavePerfDataFile(
             uint16_t recordSize,
             uint32_t recordBufferPos) noexcept
         {
-            // Add event data to vecList.
-
-            auto const unmaskedPosEnd = recordBufferPos + recordSize;
-            if (unmaskedPosEnd <= m_bufferSize)
-            {
-                // Event does not wrap.
-                vecList.Add(bufferData + recordBufferPos, recordSize);
-            }
-            else
-            {
-                // Event wraps.
-                vecList.Add(bufferData + recordBufferPos, m_bufferSize - recordBufferPos);
-                vecList.Add(bufferData, unmaskedPosEnd - m_bufferSize);
-            }
-
             // Look up the correct value for m_enumEventInfo.event_desc.
 
             m_enumEventInfo.event_desc = nullptr;
@@ -958,6 +943,22 @@ TracepointSession::SavePerfDataFile(
                     }
                 }
             }
+
+            // Add event data to vecList.
+
+            auto const unmaskedPosEnd = recordBufferPos + recordSize;
+            if (unmaskedPosEnd <= m_bufferSize)
+            {
+                // Event does not wrap.
+                vecList.Add(bufferData + recordBufferPos, recordSize);
+            }
+            else
+            {
+                // Event wraps.
+                vecList.Add(bufferData + recordBufferPos, m_bufferSize - recordBufferPos);
+                vecList.Add(bufferData, unmaskedPosEnd - m_bufferSize);
+            }
+
             return true;
         };
 
@@ -1037,14 +1038,14 @@ TracepointSession::SavePerfDataFile(
             goto Done;
         }
 
-        if (options.m_timestampRangeFirst)
+        if (options.m_timestampWrittenRangeFirst)
         {
-            *options.m_timestampRangeFirst = times.first;
+            *options.m_timestampWrittenRangeFirst = times.first;
         }
 
-        if (options.m_timestampRangeLast)
+        if (options.m_timestampWrittenRangeLast)
         {
-            *options.m_timestampRangeLast = times.last;
+            *options.m_timestampWrittenRangeLast = times.last;
         }
     }
 
@@ -1671,7 +1672,7 @@ TracepointSession::AddTracepoint(
         pAttr->use_clockid = 1;
         pAttr->write_backward = !IsRealtime();
         pAttr->wakeup_events = m_wakeupValue;
-        pAttr->clockid = m_sessionInfo.ClockId();
+        pAttr->clockid = m_sessionInfo.Clockid();
 
         // pIds will be initialized after file handle creation.
         // cIdsAdded tracks initialization.

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileWriter.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileWriter.h
@@ -213,14 +213,14 @@ namespace tracepoint_decode
 
         // Sets the data for the CLOCKID header.
         _Success_(return == 0) int
-        SetClockIdHeader(uint32_t clockid) noexcept;
+        SetClockidHeader(uint32_t clockid) noexcept;
 
         // Sets the data for the CLOCK_DATA header.
         _Success_(return == 0) int
         SetClockDataHeader(uint32_t clockid, uint64_t wallClockNS, uint64_t clockidTimeNS) noexcept;
 
         // Sets or resets the data for headers available in the specified sessionInfo:
-        // - CLOCKID: Set based on ClockId(); cleared if ClockId() == 0xFFFFFFFF.
+        // - CLOCKID: Set based on Clockid(); cleared if Clockid() == 0xFFFFFFFF.
         // - CLOCK_DATA: Set based on GetClockOffset(); cleared if !ClockOffsetKnown().
         _Success_(return == 0) int
         SetSessionInfoHeaders(PerfEventSessionInfo const& sessionInfo) noexcept;

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventAbi.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventAbi.h
@@ -18,6 +18,14 @@
 #define _Pre_cap_(c)
 #endif
 
+#ifndef _ltpDecl
+#ifdef _WIN32
+#define _ltpDecl __cdecl
+#else
+#define _ltpDecl
+#endif
+#endif
+
 // uint32 value for perf_event_attr::type.
 enum perf_type_id : uint32_t {
     PERF_TYPE_HARDWARE = 0,
@@ -596,8 +604,8 @@ enum perf_event_type : uint32_t {
      * #define MAX_EVENT_NAME 64
      * 
      * struct perf_trace_event_type {
-     *     uint64_t	event_id;
-     *     char	name[MAX_EVENT_NAME];
+     *     uint64_t    event_id;
+     *     char    name[MAX_EVENT_NAME];
      * };
      * 
      * struct event_type_event {
@@ -644,10 +652,10 @@ enum perf_event_type : uint32_t {
      * Auxtrace type specific information. Describe me
      * 
      * struct auxtrace_info_event {
-	 *     struct perf_event_header header;
-	 *     uint32_t type;
-	 *     uint32_t reserved__; // For alignment
-	 *     uint64_t priv[];
+     *     struct perf_event_header header;
+     *     uint32_t type;
+     *     uint32_t reserved__; // For alignment
+     *     uint64_t priv[];
      * };
      */
     PERF_RECORD_AUXTRACE_INFO = 70,
@@ -659,21 +667,21 @@ enum perf_event_type : uint32_t {
      * by the CPU.
      * 
      * struct auxtrace_event {
-	 *      struct perf_event_header header;
-	 *      uint64_t size;
-	 *      uint64_t offset;
-	 *      uint64_t reference;
-	 *      uint32_t idx;
-	 *      uint32_t tid;
-	 *      uint32_t cpu;
-	 *      uint32_t reserved__; // For alignment
+     *      struct perf_event_header header;
+     *      uint64_t size;
+     *      uint64_t offset;
+     *      uint64_t reference;
+     *      uint32_t idx;
+     *      uint32_t tid;
+     *      uint32_t cpu;
+     *      uint32_t reserved__; // For alignment
      * };
      * 
      * struct aux_event {
-	 *      struct perf_event_header header;
-	 *      uint64_t	aux_offset;
-	 *      uint64_t	aux_size;
-	 *      uint64_t	flags;
+     *      struct perf_event_header header;
+     *      uint64_t    aux_offset;
+     *      uint64_t    aux_size;
+     *      uint64_t    flags;
      * };
      */
     PERF_RECORD_AUXTRACE = 71,
@@ -682,22 +690,22 @@ enum perf_event_type : uint32_t {
      * Describes an error in hardware tracing
      * 
      * enum auxtrace_error_type {
-	 *     PERF_AUXTRACE_ERROR_ITRACE  = 1,
-	 *     PERF_AUXTRACE_ERROR_MAX
+     *     PERF_AUXTRACE_ERROR_ITRACE  = 1,
+     *     PERF_AUXTRACE_ERROR_MAX
      * };
      * 
      * #define MAX_AUXTRACE_ERROR_MSG 64
      * 
      * struct auxtrace_error_event {
-	 *     struct perf_event_header header;
-	 *     uint32_t type;
-	 *     uint32_t code;
-	 *     uint32_t cpu;
-	 *     uint32_t pid;
-	 *     uint32_t tid;
-	 *     uint32_t reserved__; // For alignment
-	 *     uint64_t ip;
-	 *     char msg[MAX_AUXTRACE_ERROR_MSG];
+     *     struct perf_event_header header;
+     *     uint32_t type;
+     *     uint32_t code;
+     *     uint32_t cpu;
+     *     uint32_t pid;
+     *     uint32_t tid;
+     *     uint32_t reserved__; // For alignment
+     *     uint64_t ip;
+     *     char msg[MAX_AUXTRACE_ERROR_MSG];
      * };
      */
     PERF_RECORD_AUXTRACE_ERROR = 72,
@@ -718,8 +726,8 @@ enum perf_event_type : uint32_t {
 
     /*
      * struct compressed_event {
-     *     struct perf_event_header	header;
-     *     char				data[];
+     *     struct perf_event_header    header;
+     *     char                data[];
      * };
 
     The header is followed by compressed data frame that can be decompressed
@@ -753,12 +761,12 @@ namespace tracepoint_decode
 {
     // Returns a string for the PERF_TYPE_* enum value, e.g. "HARDWARE".
     // If enum is not recognized, formats decimal value into and returns scratch.
-    _Ret_z_ char const*
+    _Ret_z_ char const* _ltpDecl
     PerfEnumToString(perf_type_id value, _Pre_cap_(11) char* scratch) noexcept;
 
     // Returns a string for the PERF_RECORD_* enum value, e.g. "SAMPLE".
     // If enum is not recognized, formats decimal value into and returns scratch.
-    _Ret_z_ char const*
+    _Ret_z_ char const* _ltpDecl
     PerfEnumToString(perf_event_type value, _Pre_cap_(11) char* scratch) noexcept;
 }
 // namespace tracepoint_decode

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventSessionInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventSessionInfo.h
@@ -61,8 +61,11 @@ namespace tracepoint_decode
 
         // Returns the clockid of the session timestamp, e.g. CLOCK_MONOTONIC.
         // Returns 0xFFFFFFFF if the session timestamp clockid is unknown.
-        uint32_t
-        ClockId() const noexcept;
+        constexpr uint32_t
+        ClockId() const noexcept
+        {
+            return m_clockId;
+        }
 
         // Returns the CLOCK_REALTIME value that corresponds to an event timestamp of 0
         // for this session. Returns 1970 if the session timestamp offset is unknown.
@@ -70,8 +73,11 @@ namespace tracepoint_decode
         ClockOffset() const noexcept;
 
         // Returns true if session clock offset is known.
-        bool
-        ClockOffsetKnown() const noexcept;
+        constexpr bool
+        ClockOffsetKnown() const noexcept
+        {
+            return m_clockOffsetKnown;
+        }
 
         // Converts time from session timestamp to real-time (time since 1970):
         // TimeToRealTime = ClockOffset() + time.

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventSessionInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventSessionInfo.h
@@ -62,7 +62,7 @@ namespace tracepoint_decode
         // Returns the clockid of the session timestamp, e.g. CLOCK_MONOTONIC.
         // Returns 0xFFFFFFFF if the session timestamp clockid is unknown.
         constexpr uint32_t
-        ClockId() const noexcept
+        Clockid() const noexcept
         {
             return m_clockId;
         }

--- a/libtracepoint-decode-cpp/src/PerfDataFileWriter.cpp
+++ b/libtracepoint-decode-cpp/src/PerfDataFileWriter.cpp
@@ -449,7 +449,7 @@ PerfDataFileWriter::SetSampleTimeHeader(uint64_t first, uint64_t last) noexcept
 }
 
 _Success_(return == 0) int
-PerfDataFileWriter::SetClockIdHeader(uint32_t clockid) noexcept
+PerfDataFileWriter::SetClockidHeader(uint32_t clockid) noexcept
 {
     uint64_t const clockid64 = clockid;
     return SetHeader(PERF_HEADER_CLOCKID, &clockid64, sizeof(clockid64));
@@ -477,14 +477,14 @@ PerfDataFileWriter::SetSessionInfoHeaders(PerfEventSessionInfo const& sessionInf
 {
     int error = 0;
 
-    auto const clockid = sessionInfo.ClockId();
+    auto const clockid = sessionInfo.Clockid();
     if (clockid == 0xFFFFFFFF)
     {
         m_headers[PERF_HEADER_CLOCKID].clear();
     }
     else
     {
-        error = SetClockIdHeader(clockid);
+        error = SetClockidHeader(clockid);
         if (error != 0)
         {
             goto Done;

--- a/libtracepoint-decode-cpp/src/PerfEventAbi.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventAbi.cpp
@@ -111,7 +111,7 @@ EnumToString(
     return str;
 }
 
-_Ret_z_ char const*
+_Ret_z_ char const* _ltpDecl
 PerfEnumToString(perf_type_id value, _Pre_cap_(11) char* scratch) noexcept
 {
     static char const* const names[] = {
@@ -126,7 +126,7 @@ PerfEnumToString(perf_type_id value, _Pre_cap_(11) char* scratch) noexcept
     return EnumToString(names, ArrayCount(names), value, scratch);
 }
 
-_Ret_z_ char const*
+_Ret_z_ char const* _ltpDecl
 PerfEnumToString(perf_event_type value, _Pre_cap_(11) char* scratch) noexcept
 {
     static char const* const names[] = {

--- a/libtracepoint-decode-cpp/src/PerfEventSessionInfo.cpp
+++ b/libtracepoint-decode-cpp/src/PerfEventSessionInfo.cpp
@@ -102,22 +102,10 @@ PerfEventSessionInfo::GetClockOffset(
     }
 }
 
-uint32_t
-PerfEventSessionInfo::ClockId() const noexcept
-{
-    return m_clockId;
-}
-
 PerfEventTimeSpec
 PerfEventSessionInfo::ClockOffset() const noexcept
 {
     return { m_clockOffsetSec, m_clockOffsetNsec };
-}
-
-bool
-PerfEventSessionInfo::ClockOffsetKnown() const noexcept
-{
-    return m_clockOffsetKnown;
 }
 
 PerfEventTimeSpec


### PR DESCRIPTION
Add options for the `SavePerfDataFile` method:
- TimestampFilter: Only events with timestamps within the filter range will
  be written to the file.
- TimestampRange: Receives the timestamp range of the saved events, e.g.
  so that you can track the ending timestamp of one file and use it as
  the starting timestamp of the next file.

Note that we haven't made any releases with the `SavePerfDataFile`
method yet so this isn't included in the changelog.

Also, some minor cleanup:
- Change "TracePoint" to "Tracepoint" to be consistent with Linux docs
  and the rest of the LinuxTracepoints repo.
- Refactor the EnableTracepoints and DisableTracepoints to use helper
  methods SetTracepointEnableState and AddTracepoint.
- Refactor fields to group them into Constant, State, Statistics, and
  Transient.