### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LinuxTracepoints Change Log
 
-## v1.3.1 (TBD)
+## v1.3.1 (2024-01-11)
 
 - `TracepointSession` supports per-CPU buffer sizes (including 0) to allow
   memory usage optimization when trace producers are known to be bound to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(LinuxTracepoints
-    VERSION 1.3.0)
+    VERSION 1.3.1)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-control-cpp
-    VERSION 1.3.0
+    VERSION 1.3.1
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)


### PR DESCRIPTION
Update libtracepoint-control version to v1.3.1.

Update overall repo version to v1.3.1.

Keep other libraries at version v1.3.0 because not changed.

Declare today as the release date for v1.3.1.