### PR TITLE
Fix permissions for codeql

### DIFF
--- a/.github/workflows/CMake.yml
+++ b/.github/workflows/CMake.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '17 17 * * 2'
 
+permissions:
+  security-events: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
> Permissions
> All advanced setup code scanning workflows must have the security-events: write permission. 