### PR TITLE
Open user_events_data for WRONLY instead of RDWR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # LinuxTracepoints Change Log
 
+## v1.3.2 (2024-02-27)
+
+- Bug fix: Open `user_events_data` for `O_WRONLY` instead of `O_RDWR`.
+
 ## v1.3.1 (2024-01-11)
 
 - `TracepointSession` supports per-CPU buffer sizes (including 0) to allow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(LinuxTracepoints
-    VERSION 1.3.1)
+    VERSION 1.3.2)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ events and for generating Tracepoint events from user mode using the
     the following line to your `/etc/fstab` file:
     `tracefs /sys/kernel/tracing tracefs defaults 0 0`
   - The user that will generate events must have `x` access to the `tracing`
-    directory and `rw` access to the `tracing/user_events_data` file. One
+    directory and `w` access to the `tracing/user_events_data` file. One
     possible implementation is to create a `tracers` group, then:
     - `chgrp tracers /sys/kernel/tracing`
     - `chgrp tracers /sys/kernel/tracing/user_events_data`
     - `chmod g+x /sys/kernel/tracing`
-    - `chmod g+rw /sys/kernel/tracing/user_events_data`
+    - `chmod g+w /sys/kernel/tracing/user_events_data`
 - Use one of the event generation APIs to write a program that generates events.
   - C/C++ programs can use
     [tracepoint-provider.h](libtracepoint/include/tracepoint/tracepoint-provider.h)

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-control-cpp
-    VERSION 1.3.1
+    VERSION 1.3.2
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint-control-cpp/src/TracepointPath.cpp
+++ b/libtracepoint-control-cpp/src/TracepointPath.cpp
@@ -202,7 +202,7 @@ UpdateUserEventsDataFile(int* pStaticFile) noexcept
         memcpy(fileName, tracingDir, cchTracingDir);
         memcpy(fileName + cchTracingDir, USER_EVENTS_DATA, sizeof(USER_EVENTS_DATA));
 
-        newFileOrError = open(fileName, O_RDWR);
+        newFileOrError = open(fileName, O_WRONLY);
         if (0 > newFileOrError)
         {
             newFileOrError = -GetFailureErrno();

--- a/libtracepoint/CMakeLists.txt
+++ b/libtracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint
-    VERSION 1.3.0
+    VERSION 1.3.2
     DESCRIPTION "Linux tracepoints interface for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint/src/tracepoint.c
+++ b/libtracepoint/src/tracepoint.c
@@ -137,7 +137,7 @@ user_events_data_update(int* staticFileOrError)
     // This improves performance and also makes it simpler to set up a container:
     // The container creator will have to project the user_events_data file but
     // won't need to make a dummy /proc/mounts file for us to parse.
-    newFileOrError = open("/sys/kernel/tracing/user_events_data", O_RDWR);
+    newFileOrError = open("/sys/kernel/tracing/user_events_data", O_WRONLY);
     if (0 <= newFileOrError)
     {
         // Success.
@@ -263,7 +263,7 @@ user_events_data_update(int* staticFileOrError)
         {
             // path is now something like "/sys/kernel/tracing/user_events_data\0" or
             // "/sys/kernel/debug/tracing/user_events_data\0".
-            newFileOrError = open(path, O_RDWR);
+            newFileOrError = open(path, O_WRONLY);
             if (0 > newFileOrError)
             {
                 newFileOrError = -get_failure_errno();


### PR DESCRIPTION
Minimize permissions needed on the user_events_data file: we were opening it for RDWR, but we only need to write, so fix by opening it for WRONLY.