### PR TITLE
eventheader-register cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # LinuxTracepoints Change Log
 
+## v1.3.3 (TBD)
+
+- libtracepoint: new tool `tracepoint-register` for pre-registering
+  tracepoints.
+- libeventheader: existing tool `eventheader-register` is deprecated in
+  favor of `tracepoint-register`.
+
 ## v1.3.2 (2024-02-27)
 
 - Bug fix: Open `user_events_data` for `O_WRONLY` instead of `O_RDWR`.

--- a/README.md
+++ b/README.md
@@ -109,16 +109,18 @@ events and for generating Tracepoint events from user mode using the
 - Note that tracepoints must be registered before you can start collecting
   them. The `perf` command will report an error if the tracepoint is not yet
   registered.
-  - You can usually register tracepoints by running the program that generates
+  - You can usually register tracepoints by starting the program that generates
     them. Most programs will register all of their tracepoints when they start
-    running.
-  - For eventheader-enabled Tracepoint events, you can also use the
-    [`eventheader-register`](libeventheader-tracepoint/tools/eventheader-register.cpp)
-    tool to pre-register an event based on its tracepoint name so you can start
-    collecting it before starting the program that generates it. If writing
-    your own event collection tool that collects eventheader-enabled events,
-    you might do something similar in your own tool to pre-register the events
-    that you need to collect.
+    running. (They will usually unregister when they stop running.)
+  - You can also use the
+    [`tracepoint-register`](libtracepoint/tools/tracepoint-register.cpp)
+    tool to pre-register an event so you can start collecting it before
+    starting the program that generates it.
+  - If writing your own event collection tool, you might do something similar
+    in your tool to pre-register the events that you need to collect. For
+    example, you might use the `PreregisterTracepoint` or
+    `PreregisterEventHeaderTracepoint` methods of the `TracepointCache` class
+    in [`libtracepoint=control`](libtracepoint-control-cpp).
 - Use the [`decode-perf`](libeventheader-decode-cpp/tools/decode-perf.cpp)
   tool to decode the `perf.data` file to JSON text, or write your own decoding
   tool using [libtracepoint-decode-cpp](libtracepoint-decode-cpp) and

--- a/libeventheader-tracepoint/README.md
+++ b/libeventheader-tracepoint/README.md
@@ -45,8 +45,7 @@ keyword, etc.) will share one Tracepoint.
   collect but the tracepoints have not been registered yet (because the
   programs that generate the tracepoints haven't run yet), I can just register
   them myself since any registration will be equivalent to the "real"
-  registrations. (Sample tool to pre-register events:
-  [eventheader-register.cpp](samples/eventheader-register.cpp).)
+  registrations.
 
 We define a naming scheme to be used for the shared Tracepoints:
 

--- a/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
+++ b/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
@@ -216,7 +216,7 @@ namespace ehd
                 auto h = sizeof(size_t) == 8
                     ? static_cast<size_t>(0xcbf29ce484222325)
                     : static_cast<size_t>(0x811c9dc5);
-                auto const p = reinterpret_cast<uint8_t const*>(&a.Keyword);
+                auto const p = reinterpret_cast<uint8_t const*>(&a);
                 assert(&a.Level - p == 8);
                 for (unsigned i = 0; i != 9; i += 1)
                 {
@@ -229,7 +229,7 @@ namespace ehd
             bool
             operator()(EventKey const& a, EventKey const& b) const noexcept
             {
-                return 0 == memcmp(&a.Keyword, &b.Keyword, 9);
+                return 0 == memcmp(&a, &b, 9);
             }
         };
 

--- a/libeventheader-tracepoint/tools/CMakeLists.txt
+++ b/libeventheader-tracepoint/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Deprecated - prefer tracepoint-register from libtracepoint.
 add_executable(eventheader-register
     eventheader-register.cpp)
 target_link_libraries(eventheader-register

--- a/libeventheader-tracepoint/tools/eventheader-register.cpp
+++ b/libeventheader-tracepoint/tools/eventheader-register.cpp
@@ -26,6 +26,9 @@ Usage: eventheader-register TracepointName1 [TracepointName2]...
 Pre-registers eventheader tracepoint names so that you can start a trace before
 running the program that generates the events.
 
+Note: This tool is deprecated. Prefer the tracepoint-register tool from
+libtracepoint.
+
 Each TracepointName must be formatted as "<providerName>_L<level>K<keyword>"
 or "<providerName>_L<level>K<keyword>G<providerGroup>". For example,
 "MyProvider_L2K1" or "MyProvider_L5K3ffGmygroup".

--- a/libtracepoint/README.md
+++ b/libtracepoint/README.md
@@ -23,6 +23,10 @@ alternative scenarios, e.g. testing with a mock tracing implementation.
 to use a higher-level library implemented on top of this interface, such as
 `tracepoint-provider.h`.
 
+This library includes a `tracepoint-register` tool that can be used to
+pre-register a `user_event` tracepoint. This allows you to start collecting a
+trace before the corresponding scenario starts running.
+
 Alternative implementations of this interface are expected, e.g. a mock
 tracing implementation could be used for testing. A developer would
 select the alternative implementation by linking against a different


### PR DESCRIPTION
- Clean up the documentation referenceing eventheader-register.
- Fix CodeQL warning about `&a.Keyword` not being 9 bytes long.