### PR TITLE
BUG FIX: EADDRINUSE returned during TraceLoggingRegister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # LinuxTracepoints Change Log
 
-## v1.3.3 (TBD)
+## v1.3.3 (2024-04-12)
 
+- BUG FIX: EADDRINUSE returned during TraceLoggingRegister on newer kernels.
+  The "name already in use" detection splits on whitespace, while all other
+  processing splits on semicolon. Fix by adding space after each semicolon
+  in `EVENTHEADER_COMMAND_TYPES`.
 - libtracepoint: new tool `tracepoint-register` for pre-registering
   tracepoints.
 - libeventheader: existing tool `eventheader-register` is deprecated in

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(eventheader-tracepoint
-    VERSION 1.3.2
+    VERSION 1.3.3
     DESCRIPTION "EventHeader-encoded Linux tracepoints for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libeventheader-tracepoint/include/eventheader/eventheader.h
+++ b/libeventheader-tracepoint/include/eventheader/eventheader.h
@@ -213,7 +213,7 @@ typedef struct eventheader {
 Type string for use in the DIAG_IOCSREG command string.
 Use EVENTHEADER_FORMAT_COMMAND to generate the full command string.
 */
-#define EVENTHEADER_COMMAND_TYPES "u8 eventheader_flags;u8 version;u16 id;u16 tag;u8 opcode;u8 level"
+#define EVENTHEADER_COMMAND_TYPES "u8 eventheader_flags; u8 version; u16 id; u16 tag; u8 opcode; u8 level"
 
 /*
 eventheader_flags enum: Values for eventheader.flags.

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint-control-cpp
-    VERSION 1.3.2
+    VERSION 1.3.3
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)

--- a/libtracepoint-control-cpp/src/TracepointCache.cpp
+++ b/libtracepoint-control-cpp/src/TracepointCache.cpp
@@ -63,7 +63,7 @@ struct user_unreg63 {
 #define DIAG_IOCSUNREG _IOW(DIAG_IOC_MAGIC, 2, struct user_unreg63*)
 
 //#include <eventheader.h>
-#define EVENTHEADER_COMMAND_TYPES "u8 eventheader_flags;u8 version;u16 id;u16 tag;u8 opcode;u8 level"
+#define EVENTHEADER_COMMAND_TYPES "u8 eventheader_flags; u8 version; u16 id; u16 tag; u8 opcode; u8 level"
 enum {
     // Maximum length of a Tracepoint name "ProviderName_Attributes", including nul termination.
     EVENTHEADER_NAME_MAX = 256,

--- a/libtracepoint/CMakeLists.txt
+++ b/libtracepoint/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tracepoint
-    VERSION 1.3.2
+    VERSION 1.3.3
     DESCRIPTION "Linux tracepoints interface for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES C CXX)

--- a/libtracepoint/tools/tracepoint-register.cpp
+++ b/libtracepoint/tools/tracepoint-register.cpp
@@ -12,7 +12,7 @@
 #include <forward_list>
 
 // From eventheader/eventheader.h:
-#define EVENTHEADER_COMMAND_TYPES "u8 eventheader_flags;u8 version;u16 id;u16 tag;u8 opcode;u8 level"
+#define EVENTHEADER_COMMAND_TYPES "u8 eventheader_flags; u8 version; u16 id; u16 tag; u8 opcode; u8 level"
 enum {
     // Maximum length of a Tracepoint name "ProviderName_Attributes", including nul termination.
     EVENTHEADER_NAME_MAX = 256,


### PR DESCRIPTION
Fix EADDRINUSE returned by TraceLoggingRegister on newer kernels. The "name already in use" detection splits on whitespace, while all other processing splits on semicolon. Fix by adding space after each semicolon in `EVENTHEADER_COMMAND_TYPES`.