### PR TITLE
SavePerfDataFile includes PERF_RECORD_FINISHED_INIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # LinuxTracepoints Change Log
 
+## v1.3.4 (TBD)
+
+- libtracepoint-control: TracepointSession SavePerfDataFile adds a
+  `PERF_RECORD_FINISHED_INIT` record to the generated perf.data file.
+
 ## v1.3.3 (2024-04-15)
 
 - BUG FIX: EADDRINUSE returned during TraceLoggingRegister on newer kernels.

--- a/libtracepoint-control-cpp/src/TracepointSession.cpp
+++ b/libtracepoint-control-cpp/src/TracepointSession.cpp
@@ -927,6 +927,17 @@ TracepointSession::SavePerfDataFile(
         goto Done;
     }
 
+    // Mark the end of the "synthetic events" section (currently empty).
+
+    static auto constexpr xPERF_RECORD_FINISHED_INIT = static_cast<perf_event_type>(82);
+    static perf_event_header constexpr finishedInit = {
+        xPERF_RECORD_FINISHED_INIT, 0, sizeof(perf_event_header) };
+    error = output.WriteEventData(&finishedInit, sizeof(finishedInit));
+    if (error != 0)
+    {
+        goto Done;
+    }
+
     // Write event data:
 
     if (m_bufferLeaderFiles != nullptr)


### PR DESCRIPTION
Some perf.data parsers expect a `PERF_RECORD_FINISHED_INIT` record to indicate the end of the "startup" events (system information, similar to ETW rundown). Add this event to the trace recorded by SavePerfDataFile.