### PR TITLE
TracepointSpec - expose a Trim method

### DIFF
--- a/libtracepoint-control-cpp/include/tracepoint/TracepointSpec.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointSpec.h
@@ -53,6 +53,7 @@ namespace tracepoint_control
     */
     struct TracepointSpec
     {
+        std::string_view Trimmed = {};    // Input with leading/trailing whitespace removed = Trim(specString).
         std::string_view SystemName = {}; // e.g. "user_events".
         std::string_view EventName = {};  // e.g. "MyEvent" or "MyProvider_L2K1Gmygroup".
         std::string_view Flags = {};      // e.g. "" or "flag1,flag2".
@@ -90,7 +91,14 @@ namespace tracepoint_control
           Examples: "ProviderName_L1K1", or "SystemName:ProviderName_L1KffGgroup:Flags".
         */
         explicit
-        TracepointSpec(std::string_view const specString);
+        TracepointSpec(std::string_view const specString) noexcept;
+
+        /*
+        Returns specString with all leading and trailing whitespace removed.
+        Uses the same definition of whitespace as the TracepointSpec constructor.
+        */
+        static std::string_view
+        Trim(std::string_view const specString) noexcept;
     };
 }
 // namespace tracepoint_control

--- a/libtracepoint-control-cpp/src/TracepointCache.cpp
+++ b/libtracepoint-control-cpp/src/TracepointCache.cpp
@@ -379,7 +379,6 @@ TracepointCache::PreregisterTracepointDefinition(TracepointSpec const& spec) noe
                 command = commandHeap.data();
             }
 
-
             snprintf(command, commandSize, "%.*s%s%.*s %s",
                 eventNameSize, spec.EventName.data(),
                 spec.Flags.empty() ? "" : ":",

--- a/libtracepoint-control-cpp/src/TracepointSpec.cpp
+++ b/libtracepoint-control-cpp/src/TracepointSpec.cpp
@@ -27,7 +27,7 @@ CountLeadingWhitespace(std::string_view str)
     return pos;
 }
 
-TracepointSpec::TracepointSpec(std::string_view const specString)
+TracepointSpec::TracepointSpec(std::string_view const specString) noexcept
 {
     bool identifier;
     bool hasFields = false;
@@ -42,18 +42,10 @@ TracepointSpec::TracepointSpec(std::string_view const specString)
     6. SystemName ':' EventName (':' Flags)? (WS Fields*)?
     */
 
-    // Trim trailing whitespace and semicolons.
-    size_t trimmedSize;
-    for (trimmedSize = specString.size(); trimmedSize != 0; trimmedSize -= 1)
-    {
-        if (!AsciiIsSpace(specString[trimmedSize - 1]))
-        {
-            break;
-        }
-    }
+    auto const trimmed = Trim(specString);
+    Trimmed = trimmed;
 
-    auto const trimmed = specString.substr(0, trimmedSize);
-    size_t pos = CountLeadingWhitespace(trimmed);
+    size_t pos = 0;
     if (pos == trimmed.size())
     {
         Kind = TracepointSpecKind::Empty;
@@ -286,4 +278,29 @@ Done:
     {
         Kind = TracepointSpecKind::EventHeaderDefinition;
     }
+}
+
+std::string_view
+TracepointSpec::Trim(std::string_view const str) noexcept
+{
+    size_t startPos;
+    size_t endPos;
+
+    for (startPos = 0; startPos != str.size(); startPos += 1)
+    {
+        if (!AsciiIsSpace(str[startPos]))
+        {
+            break;
+        }
+    }
+
+    for (endPos = str.size(); endPos != startPos; endPos -= 1)
+    {
+        if (!AsciiIsSpace(str[endPos - 1]))
+        {
+            break;
+        }
+    }
+
+    return str.substr(startPos, endPos - startPos);
 }

--- a/libtracepoint/include/tracepoint/tracepoint-provider.h
+++ b/libtracepoint/include/tracepoint/tracepoint-provider.h
@@ -146,7 +146,6 @@ A symbol declared by TPP_DECLARE_PROVIDER must later be defined in a
     _tpp_EXTERN_C struct _tpp_provider_symbol ProviderSymbol __attribute__((visibility("hidden"))); /* Empty provider variable to help with code navigation. */ \
     _tpp_EXTERN_C tracepoint_provider_state _tpp_PASTE2(_tppProvState_, ProviderSymbol) __attribute__((visibility("hidden")))  /* Actual provider variable is hidden behind prefix. */
 
-
 /*
 Macro TPP_DEFINE_PROVIDER(ProviderSymbol):
 Invoke this macro to define the symbol for a provider. A provider is a


### PR DESCRIPTION
TracepointSpec is a class for parsing user-supplied input. The first thing it does is trim leading/trailing whitespace. It provides access to several parsed-out chunks of the input, but does not provide access to this trimmed version of the full input.

It seems likely that callers will want access to this trimmed version of the user-supplied input, whether for logging or for error reporting. For example, the tracepoint-collect tool is doing its own trimming.

Provide access to the trimming functionality so callers don't have to duplicate it.

- Provide a static Trim method that can be used before calling the constructor to access the trimmed version. Useful if we need to allocate storage for the spec string (has to happen before parsing since TracepointSpec is a non-owning view).
- Provide a Trimmed field that stores the trimmed string (useful for logging or error messages after calling the constructor).