### PR TITLE
decode-perf - show event name even when no EVENT_DESC

### DIFF
--- a/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
+++ b/libtracepoint-control-cpp/include/tracepoint/TracepointSession.h
@@ -1036,7 +1036,8 @@ namespace tracepoint_control
           PERF_RECORD_THREAD_MAP, PERF_RECORD_CPU_MAP).
         - Call writer.WriteFinishedInit() to write a PERF_RECORD_FINISHED_INIT record.
         - Call FlushToWriter(writer, &writtenRange) to write the sample events as they
-          arrive (e.g. each time session.WaitForWakeup() returns).
+          arrive (e.g. each time session.WaitForWakeup() returns) and call
+          writer.WriteFinishedRound() each time flush is complete.
         - Call SetWriterHeaders(writer, &writtenRange) to write system information headers.
         - Call writer.FinalizeAndClose() to close the file.
 
@@ -1050,8 +1051,6 @@ namespace tracepoint_control
         - Write buffer's data to the file.
         - Unpause the buffer.
 
-        Then write a PERF_RECORD_FINISHED_ROUND record to the file.
-
         Note that events are lost if they arrive while the buffer is paused. The lost
         event count indicates how many events were lost during previous pauses that would
         have been part of a enumeration if there had been no pauses. It does not include
@@ -1064,9 +1063,6 @@ namespace tracepoint_control
 
         - Write buffer's pending (unconsumed) events to the file.
         - Mark the enumerated events as consumed, making room for subsequent events.
-
-        If any events were written the first time, repeat the process a second time.
-        Then write a PERF_RECORD_FINISHED_ROUND record to the file.
 
         Note that events are lost if they arrive while the buffer is full. The lost
         event count indicates how many events were lost during previous periods when

--- a/libtracepoint-control-cpp/tools/tracepoint-collect.cpp
+++ b/libtracepoint-control-cpp/tools/tracepoint-collect.cpp
@@ -14,6 +14,7 @@ Simple tool for collecting tracepoints into perf.data files.
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include <vector>
 

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileDefs.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfDataFileDefs.h
@@ -68,7 +68,7 @@ namespace tracepoint_decode
     struct PerfEventDesc
     {
         perf_event_attr const* attr;    // NULL for unknown id.
-        _Field_z_ char const* name;     // "" if no name available.
+        _Field_z_ char const* name;     // "" if no name available, e.g. if no PERF_HEADER_EVENT_DESC header.
         PerfEventMetadata const* metadata; // NULL if no metadata available.
         _Field_size_(ids_count) uint64_t const* ids; // The sample_ids that share this descriptor.
         uint32_t ids_count;

--- a/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
+++ b/libtracepoint-decode-cpp/include/tracepoint/PerfEventInfo.h
@@ -65,6 +65,8 @@ namespace tracepoint_decode
 
         // Requires: GetSampleEventInfo() succeeded.
         // Returns: event_desc->name.
+        // May be "", e.g. if no PERF_HEADER_EVENT_DESC header. In that case,
+        // caller should check for a name in Metadata().
         _Ret_z_ char const*
         Name() const noexcept;
 


### PR DESCRIPTION
Summary:

- Formatting code should look for provider/event names in format metadata if they aren't available in the EVENT_DESC metadata.
- Correct comments indicating that FlushToWriter will write a FinishedRound event. I was thinking about doing that, and wrote the comment accordingly, but later decided against it and forgot to update the comment.
- Add missing `#include <unistd.h>`. (Whether or not it's actually needed depends on the SDK you're building against, which is how it got missed before.)
- Update comments to point out that event name might be "" if EVENT_DESC header is not present, and to note that the caller might want to use format metadata as a fallback.

Background:

For non-eventheader events, the event name comes from the EVENT_DESC header in the perf.data file. That header is optional. When it's missing, the previous version of decode-perf didn't get event names for non-eventheader events.

However, most tracepoints have associated format information, and that has the system name and the tracepoint name. For tracepoints, the event name is tracepoint name + ':' + system name, so that means we can reconstruct the event name from format info  even when EVENT_DESC is missing.

Fix the decode logic to notice when EVENT_DESC is missing and to get the system name and tracepoint name from format in that case.