### PR TITLE
Clarify C/C++ language requirements

### DIFF
--- a/libeventheader-decode-cpp/CMakeLists.txt
+++ b/libeventheader-decode-cpp/CMakeLists.txt
@@ -7,6 +7,7 @@ project(eventheader-decode-cpp
     LANGUAGES CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+set(CMAKE_CXX_STANDARD 98)  # Ensure projects declare minimum C++ requirement.
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 set(BUILD_TOOLS ON CACHE BOOL "Build tool code")
 

--- a/libeventheader-decode-cpp/include/eventheader/EventEnumerator.h
+++ b/libeventheader-decode-cpp/include/eventheader/EventEnumerator.h
@@ -5,6 +5,10 @@
 #ifndef _included_EventEnumerator_h
 #define _included_EventEnumerator_h 1
 
+#if __cplusplus < 201100L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201100L)
+#error EventEnumerator.h requires C++11 or later.
+#endif
+
 #include <eventheader/eventheader.h>
 #include <stdint.h>
 #include <errno.h>

--- a/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
+++ b/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
@@ -5,6 +5,10 @@
 #ifndef _included_EventFormatter_h
 #define _included_EventFormatter_h 1
 
+#if __cplusplus < 201100L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201100L)
+#error EventFormatter.h requires C++11 or later.
+#endif
+
 #include "EventEnumerator.h"
 #include <string>
 

--- a/libeventheader-decode-cpp/src/CMakeLists.txt
+++ b/libeventheader-decode-cpp/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(DECODE_HEADERS
 set_target_properties(eventheader-decode PROPERTIES
     PUBLIC_HEADER "${DECODE_HEADERS}")
 target_compile_features(eventheader-decode
+    INTERFACE cxx_std_11
     PRIVATE cxx_std_17)
 install(TARGETS eventheader-decode
     EXPORT eventheader-decodeTargets

--- a/libeventheader-tracepoint/CMakeLists.txt
+++ b/libeventheader-tracepoint/CMakeLists.txt
@@ -7,6 +7,8 @@ project(eventheader-tracepoint
     LANGUAGES C CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+set(CMAKE_C_STANDARD 90)    # Ensure projects declare minimum C requirement.
+set(CMAKE_CXX_STANDARD 98)  # Ensure projects declare minimum C++ requirement.
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 
 if(WIN32)

--- a/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
+++ b/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
@@ -64,6 +64,10 @@ Notes:
 #ifndef _included_EventHeaderDynamic_h
 #define _included_EventHeaderDynamic_h 1
 
+#if __cplusplus < 201703L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201703L)
+#error EventHeaderDynamic.h requires C++17 or later.
+#endif
+
 #include "eventheader-tracepoint.h"
 #include <assert.h>
 #include <string.h>

--- a/libeventheader-tracepoint/include/eventheader/eventheader.h
+++ b/libeventheader-tracepoint/include/eventheader/eventheader.h
@@ -569,7 +569,7 @@ typedef enum event_field_encoding {
 
 } event_field_encoding;
 
-#if defined(__cplusplus) || defined(static_assert)
+#if defined(static_assert) || (defined(__cplusplus) && __cplusplus >= 200410) || defined(_MSVC_LANG)
 static_assert(event_field_encoding_max <= event_field_encoding_carray_flag, "Too many encodings.");
 static_assert(event_field_encoding_invalid != event_field_encoding_value_long, "Unsupported sizeof(long).");
 static_assert(event_field_encoding_invalid != event_field_encoding_value_ptr, "Unsupported sizeof(void*).");

--- a/libeventheader-tracepoint/samples/CMakeLists.txt
+++ b/libeventheader-tracepoint/samples/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(eventheader-sample
     sample.cpp)
 target_link_libraries(eventheader-sample
     PUBLIC eventheader-tracepoint tracepoint)
+target_compile_features(eventheader-sample
+    PRIVATE cxx_std_11)
 
 add_executable(eventheader-tracepoint-sample
     tracepoint-sample.cpp
@@ -17,7 +19,7 @@ add_executable(eventheader-tracepoint-sample
 target_link_libraries(eventheader-tracepoint-sample
     PUBLIC eventheader-tracepoint tracepoint)
 target_compile_features(eventheader-tracepoint-sample
-    PRIVATE cxx_std_17)
+    PRIVATE cxx_std_17 c_std_11)
 
 add_executable(eventheader-interceptor-sample
     interceptor-sample.cpp
@@ -27,4 +29,4 @@ add_executable(eventheader-interceptor-sample
 target_link_libraries(eventheader-interceptor-sample
     PUBLIC eventheader-tracepoint)
 target_compile_features(eventheader-interceptor-sample
-    PRIVATE cxx_std_17)
+    PRIVATE cxx_std_17 c_std_11)

--- a/libeventheader-tracepoint/src/eventheader-tracepoint.c
+++ b/libeventheader-tracepoint/src/eventheader-tracepoint.c
@@ -63,7 +63,8 @@ extern "C" {
             tracepoint_fix_array((void const**)pEventsStart, (void const**)pEventsStop);
 
         int const eventCount = (int)(adjustedEventPtrsStop - pEventsStart);
-        for (int i = 0; i < eventCount; i += 1)
+        int i;
+        for (i = 0; i < eventCount; i += 1)
         {
             eventheader_tracepoint const* const pEvent = pEventsStart[i];
 

--- a/libtracepoint-control-cpp/CMakeLists.txt
+++ b/libtracepoint-control-cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ project(tracepoint-control-cpp
     DESCRIPTION "Linux tracepoint collection for C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 98)  # Ensure projects declare minimum C++ requirement.
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")

--- a/libtracepoint-control-cpp/src/CMakeLists.txt
+++ b/libtracepoint-control-cpp/src/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CONTROL_HEADERS
 set_target_properties(tracepoint-control PROPERTIES
     PUBLIC_HEADER "${CONTROL_HEADERS}")
 target_compile_features(tracepoint-control
-    PRIVATE cxx_std_17)
+    PUBLIC cxx_std_17)
 install(TARGETS tracepoint-control
     EXPORT tracepoint-controlTargets
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracepoint)

--- a/libtracepoint-decode-cpp/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ project(tracepoint-decode-cpp
     DESCRIPTION "Tracepoint decoding for C/C++"
     HOMEPAGE_URL "https://github.com/microsoft/LinuxTracepoints"
     LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 98)  # Ensure projects declare minimum C++ requirement.
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 

--- a/libtracepoint-decode-cpp/src/CMakeLists.txt
+++ b/libtracepoint-decode-cpp/src/CMakeLists.txt
@@ -23,7 +23,7 @@ set(DECODE_HEADERS
 set_target_properties(tracepoint-decode PROPERTIES
     PUBLIC_HEADER "${DECODE_HEADERS}")
 target_compile_features(tracepoint-decode
-    PRIVATE cxx_std_17)
+    PUBLIC cxx_std_17)
 install(TARGETS tracepoint-decode
     EXPORT tracepoint-decodeTargets
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tracepoint)

--- a/libtracepoint/CMakeLists.txt
+++ b/libtracepoint/CMakeLists.txt
@@ -7,6 +7,8 @@ project(tracepoint
     LANGUAGES C CXX)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+set(CMAKE_C_STANDARD 90)    # Ensure projects declare minimum C requirement.
+set(CMAKE_CXX_STANDARD 98)  # Ensure projects declare minimum C++ requirement.
 set(BUILD_SAMPLES ON CACHE BOOL "Build sample code")
 set(BUILD_TESTS ON CACHE BOOL "Build test code")
 set(BUILD_TOOLS ON CACHE BOOL "Build tool code")

--- a/libtracepoint/include/tracepoint/tracepoint-impl.h
+++ b/libtracepoint/include/tracepoint/tracepoint-impl.h
@@ -110,7 +110,8 @@ tracepoint_open_provider_with_tracepoints_impl(
     tracepoint_definition const** adjusted_stop = (tracepoint_definition const**)
         tracepoint_fix_array((void const**)tp_definition_start, (void const**)tp_definition_stop);
     int const count = (int)(adjusted_stop - tp_definition_start);
-    for (int i = 0; i < count; i += 1)
+    int i;
+    for (i = 0; i < count; i += 1)
     {
         (void)tracepoint_connect(
             tp_definition_start[i]->state,

--- a/libtracepoint/include/tracepoint/tracepoint-provider.h
+++ b/libtracepoint/include/tracepoint/tracepoint-provider.h
@@ -438,7 +438,7 @@ corresponding function parameter.
 #endif
 
 #ifndef _tpp_NOEXCEPT
-#ifdef __cplusplus
+#if defined(__cplusplus) && __cplusplus > 201100
 #define _tpp_NOEXCEPT noexcept
 #else // __cplusplus
 #define _tpp_NOEXCEPT

--- a/libtracepoint/samples/tracepoint-sample.c
+++ b/libtracepoint/samples/tracepoint-sample.c
@@ -63,7 +63,8 @@ int main()
     printf("tracepoint_connect(tp_rel_loc): %d\n", err);
 
     printf("\n");
-    for (int iteration = 1;; iteration += 1)
+    int iteration;
+    for (iteration = 1;; iteration += 1)
     {
         printf("Writing tracepoints:\n");
 

--- a/libtracepoint/tools/CMakeLists.txt
+++ b/libtracepoint/tools/CMakeLists.txt
@@ -2,4 +2,6 @@ add_executable(tracepoint-register
     tracepoint-register.cpp)
 target_link_libraries(tracepoint-register
     PUBLIC tracepoint)
+target_compile_features(tracepoint-register
+    PRIVATE cxx_std_17)
 install(TARGETS tracepoint-register)

--- a/libtracepoint/utest/CMakeLists.txt
+++ b/libtracepoint/utest/CMakeLists.txt
@@ -1,10 +1,14 @@
 add_executable(tracepoint-utest
     tracepoint-utest.cpp)
+target_compile_features(tracepoint-utest
+    PRIVATE cxx_std_11)
 target_link_libraries(tracepoint-utest
     PUBLIC tracepoint)
 
 add_executable(tpp-utest
     tpp-utest-c.c
     tpp-utest-cpp.cpp)
+target_compile_features(tpp-utest
+    PRIVATE cxx_std_11)
 target_link_libraries(tpp-utest
     PUBLIC tracepoint)

--- a/libtracepoint/utest/tpp-utest-c.c
+++ b/libtracepoint/utest/tpp-utest-c.c
@@ -19,9 +19,18 @@ void PrintErr(char const* operation, int err)
     printf("%s: %d\n", operation, err);
 }
 
+#include <errno.h>
+
 int main()
 {
     TestC();
     TestCpp();
+
+    if (EBADF != 9)
+    {
+        printf("ERROR: EBADF != 9\n");
+        return 1;
+    }
+
     return 0;
 }

--- a/libtracepoint/utest/tpp-utest-cpp.cpp
+++ b/libtracepoint/utest/tpp-utest-cpp.cpp
@@ -13,6 +13,3 @@ int TestCpp(void)
     TPP_UNREGISTER_PROVIDER(TestProvider);
     return ok != 0 && err == 0;
 }
-
-#include <errno.h>
-static_assert(EBADF == 9, "EBADF != 9");


### PR DESCRIPTION
Some LinuxTracepoints projects do not clearly indicate their minimum language requirements. This causes problems because different customers may have a different default language version set for their environment, and the build will fail if the customer's default is lower than the unstated requirement.

To fix this, all projects that have specific language version requirements need to say so. To ensure that it stays fixed, we set our defaults to be very old. That way, any project that doesn't declare a requirement is going to get noticed (unless it works on very old language which is also ok).

- In each root project that builds C (or C++) code, declare the default C (or C++) language version to be C90 (or C++98).
- This results in build errors for projects that aren't correctly requiring language versions. Add requirements (PUBLIC, INTERFACE, or PRIVATE) as appropriate.
- In some cases where a project might have optional headers with higher requirements than the lib, add checks in the headers.
- Where appropriate, make code changes to avoid unnecessary requriements.