### PR TITLE
v1.4.0, and better input/output for decode-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # LinuxTracepoints Change Log
 
-## v1.4.0 (TBD)
+## v1.4.0 (2024-06-20)
 
 - libtracepoint-control: New `tracepoint-collect` tool that records tracepoint
   events into a perf.data file.

--- a/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
+++ b/libeventheader-decode-cpp/include/eventheader/EventFormatter.h
@@ -167,6 +167,22 @@ namespace eventheader_decode
             bool needsByteSwap);
 
         /*
+        Formats the specified event field value as a UTF-8 JSON string and appends the
+        result to dest.
+
+        Returns 0 for success, errno for error. May throw bad_alloc.
+        */
+        int
+        AppendValueAsJson(
+            std::string& dest,
+            _In_reads_bytes_(valueSize) void const* valueData,
+            uint32_t valueSize,
+            event_field_encoding encoding,
+            event_field_format format,
+            bool needsByteSwap,
+            EventFormatterJsonFlags jsonFlags = static_cast<EventFormatterJsonFlags>(0));
+
+        /*
         Formats the specified big-endian UUID value as a UTF-8 string and appends
         the result to dest. UUID is formatted as 36 chars with dashes, e.g.
         "00000000-0000-0000-0000-000000000000".

--- a/libeventheader-decode-cpp/src/EventFormatter.cpp
+++ b/libeventheader-decode-cpp/src/EventFormatter.cpp
@@ -2848,6 +2848,26 @@ EventFormatter::AppendValue(
     return err;
 }
 
+int
+EventFormatter::AppendValueAsJson(
+    std::string& dest,
+    _In_reads_bytes_(valueSize) void const* valueData,
+    uint32_t valueSize,
+    event_field_encoding encoding,
+    event_field_format format,
+    bool needsByteSwap,
+    EventFormatterJsonFlags jsonFlags)
+{
+    StringBuilder sb(dest, jsonFlags);
+    int const err = AppendValueImpl(sb, valueData, valueSize,
+        encoding, format, needsByteSwap, true);
+    if (err == 0)
+    {
+        sb.Commit();
+    }
+    return err;
+}
+
 void
 EventFormatter::AppendUuid(
     std::string& dest,

--- a/version.cmake
+++ b/version.cmake
@@ -1,8 +1,8 @@
 include_guard()
 if(NOT DEFINED LINUXTRACEPOINTS_VERSION)
-    set(LINUXTRACEPOINTS_VERSION   1.3.3)
-    set(EVENTHEADER_HEADERS_MINVER 1.3) # Referenced by libeventheader-decode-cpp
-    set(TRACEPOINT_MINVER          1.3) # Referenced by libeventheader-tracepoint
-    set(TRACEPOINT_DECODE_MINVER   1.3) # Referenced by libeventheader-decode-cpp, libtracepoint-control-cpp
-    set(TRACEPOINT_HEADERS_MINVER  1.3) # Referenced by libeventheader-tracepoint
+    set(LINUXTRACEPOINTS_VERSION   1.4.0)
+    set(EVENTHEADER_HEADERS_MINVER 1.4) # Referenced by libeventheader-decode-cpp
+    set(TRACEPOINT_MINVER          1.4) # Referenced by libeventheader-tracepoint
+    set(TRACEPOINT_DECODE_MINVER   1.4) # Referenced by libeventheader-decode-cpp, libtracepoint-control-cpp
+    set(TRACEPOINT_HEADERS_MINVER  1.4) # Referenced by libeventheader-tracepoint
 endif()


### PR DESCRIPTION
- Declare 1.4.0 release date to be 2024-06-20.
- Bump version to 1.4.0.
- Add an `AppendValueAsJson` method to `EventFormatter` since decode-perf needs it to properly escape the filename.
- Add real argument processing and good input/output file handling for decode-perf.

Details on decode-perf changes:

- Add support for `-h` and `--help` options.
- Add support for `-o` and `--output` options to specify the output file name. (Still defaults to stdout if not specified.)
- Don't output the UTF-8 BOM to TTY.
- Properly JSON-escape the filename before each group of events.