### PR TITLE
Finalize names for tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## v1.4.0 (2024-06-20)
 
-- libtracepoint-control: New `tracepoint-collect` tool that records tracepoint
-  events into a perf.data file.
+- libtracepoint-control: New `perf-collect` tool that records tracepoint events
+  into a perf.data file.
+- libeventheader-decode: renamed `decode-perf` tool to `perf-decode`.
 - libtracepoint-control: TracepointSession SavePerfDataFile adds a
   `PERF_RECORD_FINISHED_INIT` record to the generated perf.data file.
 - libeventheader: tool `eventheader-register` deleted. Instead, use

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Related repositories:
   C++ library for decoding events that use the `eventheader` envelope.
   - `EventEnumerator` class parses an event into fields.
   - `EventFormatter` class converts event data into a string.
-  - `decode-perf` tool that decodes `perf.data` files to JSON.
+  - `perf-decode` tool that decodes `perf.data` files to JSON.
 
 ## General Usage
 
@@ -111,10 +111,10 @@ Related repositories:
   restricted by default.
 
 - To collect events without writing C++ code, use the included
-  [tracepoint-collect](libtracepoint-control-cpp/tools/tracepoint-collect.cpp) tool
+  [perf-collect](libtracepoint-control-cpp/tools/perf-collect.cpp) tool
   or the Linux [`perf`](https://www.man7.org/linux/man-pages/man1/perf.1.html) tool
   to collect events to a `perf.data` file, e.g.
-  `tracepoint-collect -o File.perf user_events:MyEvent1 user_events:MyEvent2` or
+  `perf-collect -o File.perf user_events:MyEvent1 user_events:MyEvent2` or
   `perf record -o File.perf -k monotonic -e user_events:MyEvent1,user_events:MyEvent2`.
   Note that you must run the tool as a privileged user to collect events (`CAP_PERFMON`
   capability plus read access to `/sys/kernel/tracing/events`).
@@ -137,7 +137,7 @@ Related repositories:
     ok to use e.g. `perf_5.10` even if you are running a newer kernel.
 
 - Note that tracepoints must be registered before you can start collecting
-  them. The `tracepoint-collect` tool has facilities to pre-register a user_events
+  them. The `perf-collect` tool has facilities to pre-register a user_events
   tracepoint. The `perf` command will report an error if the tracepoint is not yet
   registered.
 
@@ -154,7 +154,7 @@ Related repositories:
     `PreregisterEventHeaderTracepoint` methods of the `TracepointCache` class
     in [`libtracepoint=control`](libtracepoint-control-cpp).
 
-- Use the [`decode-perf`](libeventheader-decode-cpp/tools/decode-perf.cpp)
+- Use the [`perf-decode`](libeventheader-decode-cpp/tools/perf-decode.cpp)
   tool to decode the `perf.data` file to JSON text, or write your own decoding
   tool using [libtracepoint-decode-cpp](libtracepoint-decode-cpp) and
   `libeventheader-decode-cpp`.

--- a/libeventheader-decode-cpp/README.md
+++ b/libeventheader-decode-cpp/README.md
@@ -6,6 +6,6 @@ C++ library for decoding events that use the eventheader envelope.
   Splits an eventheader-encoded event into fields.
 - **[EventFormatter.h](include/eventheader/EventFormatter.h):**
   Turns events or fields into strings.
-- **[decode-perf](samples/decode-perf.cpp):**
+- **[perf-decode](samples/perf-decode.cpp):**
   Simple tool that uses `EventFormatter` and `PerfDataFile` to decode a
   `perf.data` file into JSON text. Works on Linux or Windows.

--- a/libeventheader-decode-cpp/tools/CMakeLists.txt
+++ b/libeventheader-decode-cpp/tools/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_executable(decode-perf
-    decode-perf.cpp)
-target_link_libraries(decode-perf
+add_executable(perf-decode
+    perf-decode.cpp)
+target_link_libraries(perf-decode
     eventheader-decode
     tracepoint-decode)
-target_compile_features(decode-perf
+target_compile_features(perf-decode
     PRIVATE cxx_std_17)
-install(TARGETS decode-perf)
+install(TARGETS perf-decode)

--- a/libeventheader-decode-cpp/tools/perf-decode.cpp
+++ b/libeventheader-decode-cpp/tools/perf-decode.cpp
@@ -25,7 +25,7 @@
 
 #endif // _WIN32
 
-#define PROGRAM_NAME "decode-perf"
+#define PROGRAM_NAME "perf-decode"
 
 using namespace eventheader_decode;
 using namespace tracepoint_decode;

--- a/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
+++ b/libeventheader-tracepoint/include/eventheader/EventHeaderDynamic.h
@@ -56,7 +56,7 @@ Notes:
   "user_events:MyCompany_MyComponent_L5K1f".
 - Collect events to a file using a tool such as "perf", e.g.
   "perf record -k monotonic -e user_events:MyCompany_MyComponent_L5K1f".
-- Decode events using a tool such as "decode-perf" (from the tools in the
+- Decode events using a tool such as "perf-decode" (from the tools in the
   libeventheader-decode-cpp library).
 */
 

--- a/libtracepoint-control-cpp/samples/circular-snap.cpp
+++ b/libtracepoint-control-cpp/samples/circular-snap.cpp
@@ -53,7 +53,7 @@ public:
         int error;
 
         // Use standard tracepoint-spec parsing for the text.
-        // For details on the syntax, see the help text for the tracepoint-collect tool.
+        // For details on the syntax, see the help text for the perf-collect tool.
         TracepointSpec spec(tracepointSpecText); // Parse the text.
         switch (spec.Kind)
         {

--- a/libtracepoint-control-cpp/tools/CMakeLists.txt
+++ b/libtracepoint-control-cpp/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_executable(tracepoint-collect
-    tracepoint-collect.cpp)
-target_link_libraries(tracepoint-collect
+add_executable(perf-collect
+    perf-collect.cpp)
+target_link_libraries(perf-collect
     tracepoint-control tracepoint-decode)
-target_compile_features(tracepoint-collect
+target_compile_features(perf-collect
     PRIVATE cxx_std_17)
-install(TARGETS tracepoint-collect)
+install(TARGETS perf-collect)

--- a/libtracepoint-control-cpp/tools/perf-collect.cpp
+++ b/libtracepoint-control-cpp/tools/perf-collect.cpp
@@ -18,7 +18,7 @@ Simple tool for collecting tracepoints into perf.data files.
 
 #include <vector>
 
-#define PROGRAM_NAME "tracepoint-collect"
+#define PROGRAM_NAME "perf-collect"
 #define EXIT_SIGNALS      SIGTERM, SIGINT
 #define EXIT_SIGNALS_STR "SIGTERM or SIGINT"
 


### PR DESCRIPTION
Decide on final names for tools:

- `perf-decode` (was `decode-perf`)
- `perf-collect` (was `tracepoint-collect`)
- `tracepoint-register` (no change)