### PR TITLE
interceptor-sample - add a header for tracepoint-file

### DIFF
--- a/libeventheader-tracepoint/samples/interceptor-sample.cpp
+++ b/libeventheader-tracepoint/samples/interceptor-sample.cpp
@@ -14,8 +14,7 @@ against libtracepoint.
 #include <stdio.h>
 #include <errno.h>
 
-// Used by tracepoint-file.cpp to determine the output file name.
-extern char const* g_interceptorFileName;
+#include "tracepoint-file.h" // g_interceptorFileName
 
 // Define a symbol for a "provider" (a group of related events).
 TRACELOGGING_DEFINE_PROVIDER(

--- a/libeventheader-tracepoint/samples/tracepoint-file.cpp
+++ b/libeventheader-tracepoint/samples/tracepoint-file.cpp
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 /*
-Implementation of the tracepoint.h interface that writes events to a file.
-This is part of the eventheader-interceptor-sample program.
+tracepoint-file is an implementation of the tracepoint.h interface that writes
+events to a file. This is part of the eventheader-interceptor-sample program.
 */
 
+#include "tracepoint-file.h"
 #include <tracepoint/tracepoint.h>
 #include <tracepoint/tracepoint-impl.h>
 #include <eventheader/eventheader.h>

--- a/libeventheader-tracepoint/samples/tracepoint-file.h
+++ b/libeventheader-tracepoint/samples/tracepoint-file.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/*
+tracepoint-file is an implementation of the tracepoint.h interface that appends
+events to a file.
+
+This is part of the eventheader-interceptor-sample program, demonstrating how
+linking against tracepoint-file.o instead of libtracepoint.a causes the program
+to append events to a file instead of sending them to the Linux user_events
+facility.
+*/
+
+#pragma once
+#ifndef _included_tracepoint_file_h
+#define _included_tracepoint_file_h 1
+
+/*
+Configuration point: Controls the name of the file that will be written.
+The default value of this variable is "EventHeaderInterceptor[endian][bits].dat",
+where [endian] is "LE" or "BE" and [bits] is "32" or "64".
+
+Each open provider maintains a reference count to the file. The file is opened when
+you call tracepoint_open_provider and the reference count increments to 1. The file
+is closed when you call tracepoint_close_provider and the reference count decrements
+to 0.
+
+Changes to this variable take effect when tracepoint_open_provider is called and
+the reference count increments to 1.
+*/
+#ifdef __cplusplus
+extern "C"
+#else
+extern
+#endif
+char const* g_interceptorFileName;
+
+#endif // _included_tracepoint_file_h

--- a/libeventheader-tracepoint/utest/dat-utest.cpp
+++ b/libeventheader-tracepoint/utest/dat-utest.cpp
@@ -12,7 +12,7 @@ Verifies that the resulting .dat.actual file is the same as the .dat.expected fi
 #include <exception>
 #include <string>
 
-extern char const* g_interceptorFileName;
+#include "../samples/tracepoint-file.h" // g_interceptorFileName
 
 static std::string
 LoadFile(char const* filename)


### PR DESCRIPTION
Add a header for tracepoint-file.cpp, which provides a good place to explain what is happening with the event interceptor sample.